### PR TITLE
[shop] fix server side code

### DIFF
--- a/services/shop/app/items/[id]/DSPTag.tsx
+++ b/services/shop/app/items/[id]/DSPTag.tsx
@@ -1,3 +1,20 @@
+/*
+ Copyright 2022 Google LLC
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+      https://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+import "server-only"
 import Script from "next/script"
 
 const { SHOP_HOST, DSP_HOST, EXTERNAL_PORT } = process.env

--- a/services/shop/lib/fetcher.ts
+++ b/services/shop/lib/fetcher.ts
@@ -14,6 +14,7 @@
  limitations under the License.
  */
 
+import "server-only"
 import { cookies } from "next/headers"
 import { Item, Order } from "./items"
 

--- a/services/shop/package-lock.json
+++ b/services/shop/package-lock.json
@@ -13,6 +13,7 @@
         "next": "13.4.9",
         "react": "18.2.0",
         "react-dom": "18.2.0",
+        "server-only": "^0.0.1",
         "swr": "^2.2.0"
       },
       "devDependencies": {
@@ -3851,6 +3852,11 @@
       "engines": {
         "node": ">=10"
       }
+    },
+    "node_modules/server-only": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/server-only/-/server-only-0.0.1.tgz",
+      "integrity": "sha512-qepMx2JxAa5jjfzxG79yPPq+8BuFToHd1hm7kI+Z4zAq1ftQiP7HcxMhDDItrbtwVeLg/cY2JnKnrcFkmiswNA=="
     },
     "node_modules/setprototypeof": {
       "version": "1.2.0",

--- a/services/shop/package.json
+++ b/services/shop/package.json
@@ -14,6 +14,7 @@
     "next": "13.4.9",
     "react": "18.2.0",
     "react-dom": "18.2.0",
+    "server-only": "^0.0.1",
     "swr": "^2.2.0"
   },
   "devDependencies": {

--- a/services/shop/yarn.lock
+++ b/services/shop/yarn.lock
@@ -2130,6 +2130,11 @@ semver@^7.3.7:
   dependencies:
     lru-cache "^6.0.0"
 
+server-only@^0.0.1:
+  version "0.0.1"
+  resolved "https://registry.npmjs.org/server-only/-/server-only-0.0.1.tgz"
+  integrity sha512-qepMx2JxAa5jjfzxG79yPPq+8BuFToHd1hm7kI+Z4zAq1ftQiP7HcxMhDDItrbtwVeLg/cY2JnKnrcFkmiswNA==
+
 setprototypeof@1.2.0:
   version "1.2.0"
   resolved "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz"


### PR DESCRIPTION
currently, the error below causes on production server.

```
input: 'https://undefined:undefined/dsp-tag.js'
code: 'ERR_INVALID_URL'
```

This seems that calling process.env on client side happens and got undefined.

use `server-only` should prevent this, by only running code on server side.

https://nextjs.org/docs/getting-started/react-essentials#the-server-only-package

