### PR TITLE
Fix shop ads

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "build": "docker-compose build",
     "docker": "docker-compose build && docker-compose up",
     "deploy": "./scripts/cloudrun_deploy.sh && ./scripts/firebase_deploy.sh",
-    "clean": "docker-compose rm -af && docker volume prune -fa && docker image prune -f && docker rmi -f $(docker images -q)",
+    "clean": "docker-compose rm -f && docker volume prune -f && docker image prune -f && docker rmi -f $(docker images -q)",
     "fmt": "prettier --write ."
   },
   "devDependencies": {

--- a/services/dsp/src/index.ts
+++ b/services/dsp/src/index.ts
@@ -58,7 +58,7 @@ app.get("/interest-group.json", async (req: Request, res: Response) => {
   ssp.searchParams.append("advertiser", advertiser as string)
   ssp.searchParams.append("id", id as string)
   const videoCreative = new URL(`https://${DSP_HOST}:${EXTERNAL_PORT}/html/video-ad-creative.html`)
-  const renderUrl = 'video' === adType ? videoCreative : ssp.toString()
+  const renderUrl = "video" === adType ? videoCreative : ssp.toString()
 
   const owner = new URL(`https://${DSP_HOST}:${EXTERNAL_PORT}`)
   const biddingLogicUrl = new URL(`https://${DSP_HOST}:${EXTERNAL_PORT}/js/bidding_logic.js`)

--- a/services/dsp/src/public/html/video-ad-creative.html
+++ b/services/dsp/src/public/html/video-ad-creative.html
@@ -1,9 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
-
-<head>
+  <head>
     <meta charset="utf-8" />
     <script src="/js/video-ad-creative.js"></script>
-</head>
-
+  </head>
 </html>

--- a/services/dsp/src/public/js/join-ad-interest-group.js
+++ b/services/dsp/src/public/js/join-ad-interest-group.js
@@ -33,7 +33,7 @@ document.addEventListener("DOMContentLoaded", async (e) => {
     return console.log("[DEMO] Protected Audience API is not supported")
   }
   const interestGroup = await getInterestGroupFromServer()
-  console.log(`[DEMO] ${{interestGroup}}`)
+  console.log(`[DEMO] ${{ interestGroup }}`)
   const kSecsPerDay = 3600 * 24 * 30
   console.log(await navigator.joinAdInterestGroup(interestGroup, kSecsPerDay))
 

--- a/services/dsp/src/public/js/video-ad-creative.js
+++ b/services/dsp/src/public/js/video-ad-creative.js
@@ -1,10 +1,11 @@
-(async () => {
-    const data = {
-        adVastUrl: 'https://pubads.g.doubleclick.net/gampad/ads?' +
-        'iu=/21775744923/external/single_ad_samples&sz=640x480&' +
-        'cust_params=sample_ct%3Dlinear&ciu_szs=300x250%2C728x90&' +
-        'gdfp_req=1&output=vast&unviewed_position_start=1&env=vp&' +
-        'impl=s&correlator=',
-    }
-    window.top.postMessage(JSON.stringify(data), '*')
+;(async () => {
+  const data = {
+    adVastUrl:
+      "https://pubads.g.doubleclick.net/gampad/ads?" +
+      "iu=/21775744923/external/single_ad_samples&sz=640x480&" +
+      "cust_params=sample_ct%3Dlinear&ciu_szs=300x250%2C728x90&" +
+      "gdfp_req=1&output=vast&unviewed_position_start=1&env=vp&" +
+      "impl=s&correlator="
+  }
+  window.top.postMessage(JSON.stringify(data), "*")
 })()

--- a/services/home/docs/demos/retargeting-remarketing.md
+++ b/services/home/docs/demos/retargeting-remarketing.md
@@ -27,7 +27,7 @@ Remarketing is a type of online advertising that allows you to show ads to peopl
 
 ### Privacy Sandbox APIs
 
-- [Protected Audience API](https://developer.chrome.com/en/docs/privacy-sandbox/fledge/)
+- [Protected Audience API](https://developer.chrome.com/docs/privacy-sandbox/protected-audience/)
 
 ### Related parties
 
@@ -61,7 +61,7 @@ Using Protected Audience API, the user visits a shopping site, and gets added to
 
 #### Protected Audience Flow
 
-Below is a general introduction of Remarketing using Privacy Sandbox Protected Audience API. For further information see [Protected Audience API - Chrome Developers](https://developer.chrome.com/docs/privacy-sandbox/fledge/).
+Below is a general introduction of Remarketing using Privacy Sandbox Protected Audience API. For further information see [Protected Audience API - Chrome Developers](https://developer.chrome.com/docs/privacy-sandbox/protected-audience/#overview).
 
 ![Protected Audience Flow](./img/retargeting-remarketing-flow.png)
 
@@ -160,6 +160,20 @@ The [dsp-tags.js](https://github.com/privacysandbox/privacy-sandbox-demos/blob/9
 The iframe calls a third-party script [join-ad-interest-group.js](https://github.com/privacysandbox/privacy-sandbox-demos/blob/939dd4928ec9cb4628b3f9424081bbd912346bcf/services/dsp/src/public/js/join-ad-interest-group.js#L31) to join interest group using Protected Audience API
 
 ```js title="https://github.com/privacysandbox/privacy-sandbox-demos/blob/main/services/dsp/src/public/js/join-ad-interest-group.js"
+// Protected Audience API
+async function getInterestGroupFromServer() {
+  const currentUrl = new URL(location.href)
+  const interestGroupUrl = new URL(location.origin)
+  interestGroupUrl.pathname = "/interest-group.json"
+  for (const searchParam of currentUrl.searchParams) {
+    interestGroupUrl.searchParams.append(searchParam[0], searchParam[1])
+  }
+  const res = await fetch(interestGroupUrl)
+  if (res.ok) {
+    return res.json()
+  }
+}
+
 document.addEventListener("DOMContentLoaded", async (e) => {
   if (navigator.joinAdInterestGroup === undefined) {
     return console.log("[DEMO] Protected Audience API is not supported")
@@ -244,8 +258,8 @@ This code contains the `img` tag with `src` attribute specifying the product the
 
 ### Related API documentation
 
-- [Protected Audience API - Chrome Developers](https://developer.chrome.com/docs/privacy-sandbox/fledge/)
-- [Protected Audience API: developer guide](https://developer.chrome.com/docs/privacy-sandbox/fledge-api/)
+- [Protected Audience API - Chrome Developers](https://developer.chrome.com/docs/privacy-sandbox/protected-audience/)
+- [Protected Audience API: developer guide](https://developer.chrome.com/docs/privacy-sandbox/protected-audience-api/)
 
 </TabItem>
 </Tabs>

--- a/services/home/docs/demos/retargeting-remarketing.md
+++ b/services/home/docs/demos/retargeting-remarketing.md
@@ -86,9 +86,9 @@ Advertiser-->>Browser:return DSP tags
 Browser->>DSP:browser loads scripts from DSP
 DSP-->>Browser:returns interest group configuration
 
-Browser-->>Browser:navigator.joinAdInterestGroup(...)
+Browser-)Browser:navigator.joinAdInterestGroup(...)
 
-Browser-)Publisher:visits a news  site
+Browser->>Publisher:visits a news  site
 Publisher-->>Browser:return SSP tags
 Browser->>SSP:browser loads scripts from SSP
 SSP-->>Browser:returns auction configuration
@@ -133,9 +133,9 @@ Note right of Browser:Scenario 1 stops here
 
 ### Implementation details
 
-#### In (2) How is the user added to an Interest Group based on his browsing behavior ?
+#### How is the user added to an Interest Group based on his browsing behavior ? (see step #2 of User Journey)
 
-The shop product page [includes dsp-tag.js ](https://github.com/privacysandbox/privacy-sandbox-demos/blob/8a33afb7433ed70e639047316c5bff30d61be58b/services/shop/app/items/%5Bid%5D/page.tsx#L58) from the DSP service. This is a third-party tag from the DSP service.
+The shop product page [includes dsp-tag.js ](https://github.com/privacysandbox/privacy-sandbox-demos/blob/939dd4928ec9cb4628b3f9424081bbd912346bcf/services/shop/src/index.ts#L93) from the DSP service. This is a third-party tag from the DSP service.
 
 ```html
 <script
@@ -146,7 +146,7 @@ The shop product page [includes dsp-tag.js ](https://github.com/privacysandbox/p
 ></script>
 ```
 
-This [dsp-tags.js](https://github.com/privacysandbox/privacy-sandbox-demos/blob/main/services/dsp/src/public/dsp-tag.js) dynamically embeds an iframe
+The [dsp-tags.js](https://github.com/privacysandbox/privacy-sandbox-demos/blob/939dd4928ec9cb4628b3f9424081bbd912346bcf/services/dsp/src/public/dsp-tag.js#L17) dynamically embeds an iframe
 
 ```html
 <iframe
@@ -157,26 +157,24 @@ This [dsp-tags.js](https://github.com/privacysandbox/privacy-sandbox-demos/blob/
 ></iframe>
 ```
 
-The iframe calls a third-party script [join-ad-interest-group.js](https://github.com/privacysandbox/privacy-sandbox-demos/blob/main/services/dsp/src/public/js/join-ad-interest-group.js) to join interest group using Protected Audience API
+The iframe calls a third-party script [join-ad-interest-group.js](https://github.com/privacysandbox/privacy-sandbox-demos/blob/939dd4928ec9cb4628b3f9424081bbd912346bcf/services/dsp/src/public/js/join-ad-interest-group.js#L31) to join interest group using Protected Audience API
 
 ```js title="https://github.com/privacysandbox/privacy-sandbox-demos/blob/main/services/dsp/src/public/js/join-ad-interest-group.js"
 document.addEventListener("DOMContentLoaded", async (e) => {
-  // Protected Audience
-  const url = new URL(location.href)
-  const advertiser = url.searchParams.get("advertiser")
-  const id = url.searchParams.get("id")
-  const interestGroup = await getInterestGroup(advertiser, id)
+  if (navigator.joinAdInterestGroup === undefined) {
+    return console.log("[DEMO] Protected Audience API is not supported")
+  }
+  const interestGroup = await getInterestGroupFromServer()
+  console.log(`[DEMO] ${{ interestGroup }}`)
   const kSecsPerDay = 3600 * 24 * 30
-
-  // Join user into an interest group
-  await navigator.joinAdInterestGroup(interestGroup, kSecsPerDay)
+  console.log(await navigator.joinAdInterestGroup(interestGroup, kSecsPerDay))
 })
 ```
 
-This code sets up the interest groups options. Those options are fetched dynamically from [interest-group.json](https://github.com/privacysandbox/privacy-sandbox-demos/blob/8a33afb7433ed70e639047316c5bff30d61be58b/services/dsp/src/index.ts#L50).
-Finally the code requests the browser to [join the interest group](https://github.com/privacysandbox/privacy-sandbox-demos/blob/8a33afb7433ed70e639047316c5bff30d61be58b/services/dsp/src/public/js/join-ad-interest-group.js#L37)
+This code sets up the interest groups options. Those options are fetched dynamically from [interest-group.json](https://github.com/privacysandbox/privacy-sandbox-demos/blob/939dd4928ec9cb4628b3f9424081bbd912346bcf/services/dsp/src/index.ts#L50).
+Finally the code requests the browser to [join the interest group](https://github.com/privacysandbox/privacy-sandbox-demos/blob/939dd4928ec9cb4628b3f9424081bbd912346bcf/services/dsp/src/public/js/join-ad-interest-group.js#L38)
 
-#### In (4) how do we serve an ad relevant to the user’s interest ?
+#### How do we serve an ad relevant to the user’s interest ? (see step #4 of User Journey)
 
 The news page [includes ad-tag.js ](https://github.com/privacysandbox/privacy-sandbox-demos/blob/8a33afb7433ed70e639047316c5bff30d61be58b/services/news/src/views/index.ejs#L29)from the SSP service. This is a third-party tag from the SSP service.
 
@@ -233,20 +231,12 @@ Fenced Frame size (width and height) only allow pre-defined values, please refer
 The request to the `src` url[ returns the ad creative](https://github.com/privacysandbox/privacy-sandbox-demos/blob/8a33afb7433ed70e639047316c5bff30d61be58b/services/ssp/src/index.js#L87) to be displayed
 
 ```html
-<a
-  width="300"
-  height="250"
-  target="_blank"
-  attributionsrc=""
-  href="https://privacy-sandbox-demos-ssp.dev/move?advertiser=privacy-sandbox-demos-shop.dev&amp;id=1f45f"
->
-  <img
-    width="294"
-    height="245"
-    loading="lazy"
-    attributionsrc=""
-    src="https://privacy-sandbox-demos-ssp.dev/creative?advertiser=privacy-sandbox-demos-shop.dev&amp;id=1f45f"
-  />
+<body>
+  <a width="300" height="250" target="_blank" attributionsrc="" href="https://privacy-sandbox-demos-ssp.dev/move?advertiser=privacy-sandbox-demos-shop.dev&amp;id=1f45f">
+    <!-- smaller for avoid scrollbar -->
+    <img width="294" height="245" loading="lazy" attributionsrc="" src="https://privacy-sandbox-demos-ssp.dev/creative?advertiser=privacy-sandbox-demos-shop.dev&amp;id=1f45f">
+  </a>
+
 </a>
 ```
 

--- a/services/home/docs/demos/single-touch-conversion-attribution.md
+++ b/services/home/docs/demos/single-touch-conversion-attribution.md
@@ -29,7 +29,6 @@ Single-touch attribution models are easy to understand and implement, and they c
 ### Privacy Sandbox APIs
 
 - [Attribution Reporting API](https://developer.chrome.com/en/docs/privacy-sandbox/attribution-reporting/)
-- [Aggregation Service](https://developer.chrome.com/docs/privacy-sandbox/aggregation-service/)
 
 ### Related parties
 
@@ -109,8 +108,8 @@ Note over SSP:Scenario 1 stops here<br/>where we visualize<br/>debug reports
 
 ### Prerequisites
 
-- Chrome > v107 (Open chrome://version to look up your current version)
-- Enable Privacy Sandbox APIs (Open chrome://settings/privacySandbox to enable this setting)
+- Chrome > v115 (Open chrome://version to look up your current version)
+- Enable Privacy Sandbox APIs (Open chrome://settings/adPrivacy to enable this setting)
 - Clear your browsing history before you run one of the demo scenario below (Open chrome://settings/clearBrowserData to delete your browsing history)
 - Open chrome://attribution-internals and click “Clear all attribution data”
 
@@ -125,12 +124,12 @@ Note over SSP:Scenario 1 stops here<br/>where we visualize<br/>debug reports
 4. Observe the ad served on the news site
 
 - If you previously browsed the “shoe” product on the shop site, you will be shown an ad for the same product.
-- Displaying the ad will also register a view-through conversion **source** event into your browser using the **Attribution Reporting API**.
+- Displaying the ad will also register an attribution **source** of type **event** into your browser using the **Attribution Reporting API** (used for view-through conversion measurement)
 
 5. Click on the ad served on the news site
 
 - your browser will open a new window with the product page
-- Clicking the ad will also register a click-through conversion **source** event into your browser using the **Attribution Reporting API**.
+- Clicking the ad will also register an attribution **source** of type **navigation** into your browser using the **Attribution Reporting API** (used for click-through conversion measurement)
 
 6. Navigate to chrome://attribution-internals/ and click the `Active Sources` tab
 
@@ -140,7 +139,7 @@ Note over SSP:Scenario 1 stops here<br/>where we visualize<br/>debug reports
 8. On the cart page, click “Checkout”
 
 - In this scenario the “checkout” event is the conversion event the advertiser wants to measure to evaluate the performance of their ad campaign,
-- The checkout page registers a conversion attribution **trigger** event in the browser. The **Attribution Reporting API** logic will then process the event.
+- The checkout page **triggers** the conversion attribution for the `source` whose eTLD+1 matches the eTLD+1 of the site provided in `destination` (here privacy-sandbox-demos-shop.dev) . The **Attribution Reporting API** logic will then process the event.
 
 9. Navigate to chrome://attribution-internals/ and click the `Trigger Registration` tab
 
@@ -153,34 +152,34 @@ Note over SSP:Scenario 1 stops here<br/>where we visualize<br/>debug reports
 
 ### Implementation details
 
-#### In (5) how do we attribute the conversion to seeing an ad ?
+#### how do we attribute the conversion to seeing an ad ? (see step #5 of User Journey)
 
 First on the Attribution Source registration side.
-Look at the [code](https://github.com/privacysandbox/privacy-sandbox-demos/blob/main/services/ssp/src/views/ads.html.ejs) displaying the ad creative
+Look at the [code](https://github.com/privacysandbox/privacy-sandbox-demos/blob/939dd4928ec9cb4628b3f9424081bbd912346bcf/services/ssp/src/views/ads.html.ejs#L27) displaying the ad creative
 
 ```html
 <a
   width="300"
   height="250"
   target="_blank"
-  attributionsrc=""
-  href="https://privacy-sandbox-demos-ssp.dev/move?advertiser=privacy-sandbox-demos-shop.dev&amp;id=1f45e"
+  attributionsrc="https://privacy-sandbox-demos-ssp.dev/register-source?advertiser=privacy-sandbox-demos-shop.dev&amp;id=1f6fc"
+  href="https://privacy-sandbox-demos-ssp.dev/move?advertiser=privacy-sandbox-demos-shop.dev&amp;id=1f6fc"
 >
+  <!-- smaller for avoid scrollbar -->
   <img
     width="294"
     height="245"
     loading="lazy"
-    attributionsrc=""
-    src="https://privacy-sandbox-demos-ssp.dev/creative?advertiser=privacy-sandbox-demos-shop.dev&amp;id=1f45e"
+    attributionsrc="https://privacy-sandbox-demos-ssp.dev/register-source?advertiser=privacy-sandbox-demos-shop.dev&amp;id=1f6fc"
+    src="
+         https://privacy-sandbox-demos-ssp.dev/creative?advertiser=privacy-sandbox-demos-shop.dev&amp;id=1f6fc"
   />
 </a>
 ```
 
-The `img` tag also specifies the `attributionsrc` attribute. It means that showing this ad will register a view-through attribution source event in the browser.
-
-Now using Developers Tools, look at the HTTP request you will see a new attribute added by the browser `Attribution-Reporting-Eligible` with the value `event-source, trigger`.
-
-In the HTTP response to the `/creative` request, you will see a new header `Attribution-Reporting-Register-Source:` with a value that contains the attribution source parameters.
+The `img` tag also specifies the `attributionsrc` attribute. It means that showing this ad will register an attribution source of type `event` in the browser.
+Now using Developers Tools, look at the HTTP request you will see a new attribute added by the browser `Attribution-Reporting-Eligible` with the value `event-source, trigger`
+In the HTTP response to the `/register-source` request, you will see a new header `Attribution-Reporting-Register-Source:` with a value that contains the attribution source parameters.
 
 ```json
 {
@@ -223,7 +222,7 @@ You can also refer to the [source code](https://github.com/privacysandbox/privac
 ### Related API documentation
 
 - [Attribution Reporting - Chrome Developers](https://developer.chrome.com/docs/privacy-sandbox/attribution-reporting/)
-- [Handbook (Experiment with Attribution Reporting)](https://docs.google.com/document/d/1BXchEk-UMgcr2fpjfXrQ3D8VhTR-COGYS1cwK_nyLfg/view)
+- [Attribution Reporting - Developer Guide](https://developer.chrome.com/docs/privacy-sandbox/attribution-reporting/developer-guide/)
 - [Set up debug reports - Chrome Developers](https://developer.chrome.com/docs/privacy-sandbox/attribution-reporting-debugging/part-2/)
 
 </TabItem>

--- a/services/news/src/index.ts
+++ b/services/news/src/index.ts
@@ -22,7 +22,7 @@ const app: Application = express()
 
 const TITLE = NEWS_DETAIL
 const LOREM =
-    "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum."
+  "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum."
 
 app.use((req, res, next) => {
   res.setHeader("Origin-Trial", NEWS_TOKEN as string)
@@ -39,7 +39,7 @@ app.get("/", async (req: Request, res: Response) => {
     EXTERNAL_PORT,
     HOME_HOST,
     NEWS_TOKEN,
-    SSP_HOST,
+    SSP_HOST
   })
 })
 app.get("/video-ad", async (req: Request, res: Response) => {
@@ -49,9 +49,9 @@ app.get("/video-ad", async (req: Request, res: Response) => {
     EXTERNAL_PORT,
     HOME_HOST,
     NEWS_TOKEN,
-    SSP_HOST,
-  });
-});
+    SSP_HOST
+  })
+})
 
 app.listen(PORT, async () => {
   console.log(`Listening on port ${PORT}`)

--- a/services/news/src/public/css/video-ad-style.css
+++ b/services/news/src/public/css/video-ad-style.css
@@ -1,26 +1,26 @@
-
 #mainContainer {
   position: relative;
   width: 640px;
   height: 360px;
 }
-  
-#content, #adContainer {
+
+#content,
+#adContainer {
   position: absolute;
   top: 0px;
   left: 0px;
   width: 640px;
   height: 360px;
 }
-  
+
 #contentElement {
   width: 640px;
   height: 360px;
   overflow: hidden;
 }
-  
+
 #playButton {
-  margin-top:10px;
+  margin-top: 10px;
   vertical-align: top;
   width: 350px;
   height: 60px;

--- a/services/news/src/public/js/video-ad-helper.js
+++ b/services/news/src/public/js/video-ad-helper.js
@@ -3,23 +3,23 @@
 // Note that this example is provided "as is", WITHOUT WARRANTY
 // of any kind either expressed or implied.
 
-let adsManager;
-let adsLoader;
-let adDisplayContainer;
-let intervalTimer;
-let isAdPlaying;
-let isContentFinished;
-let playButton;
-let videoContent;
+let adsManager
+let adsLoader
+let adDisplayContainer
+let intervalTimer
+let isAdPlaying
+let isContentFinished
+let playButton
+let videoContent
 
 /**
  * Initializes IMA setup.
  */
 function init() {
-  videoContent = document.getElementById('contentElement');
-  playButton = document.getElementById('playButton');
-  playButton.addEventListener('click', playAds);
-  console.log('[DEMO] Organic video initialized.')
+  videoContent = document.getElementById("contentElement")
+  playButton = document.getElementById("playButton")
+  playButton.addEventListener("click", playAds)
+  console.log("[DEMO] Organic video initialized.")
 }
 
 /**
@@ -27,43 +27,40 @@ function init() {
  */
 function setUpIMA(adTagUrl) {
   if (!adTagUrl) {
-    return console.log('[DEMO] No VAST XML URL provided.')
+    return console.log("[DEMO] No VAST XML URL provided.")
   }
   // Create the ad display container.
-  createAdDisplayContainer();
+  createAdDisplayContainer()
   // Create ads loader.
-  adsLoader = new google.ima.AdsLoader(adDisplayContainer);
+  adsLoader = new google.ima.AdsLoader(adDisplayContainer)
   // Listen and respond to ads loaded and error events.
-  adsLoader.addEventListener(
-      google.ima.AdsManagerLoadedEvent.Type.ADS_MANAGER_LOADED,
-      onAdsManagerLoaded, false);
-  adsLoader.addEventListener(
-      google.ima.AdErrorEvent.Type.AD_ERROR, onAdError, false);
+  adsLoader.addEventListener(google.ima.AdsManagerLoadedEvent.Type.ADS_MANAGER_LOADED, onAdsManagerLoaded, false)
+  adsLoader.addEventListener(google.ima.AdErrorEvent.Type.AD_ERROR, onAdError, false)
 
   // An event listener to tell the SDK that our content video
   // is completed so the SDK can play any post-roll ads.
-  const contentEndedListener = function() {
+  const contentEndedListener = function () {
     // An ad might have been playing in the content element, in which case the
     // content has not actually ended.
-    if (isAdPlaying) return;
-    isContentFinished = true;
-    adsLoader.contentComplete();
-  };
-  videoContent.onended = contentEndedListener;
+    if (isAdPlaying) return
+    isContentFinished = true
+    adsLoader.contentComplete()
+  }
+  videoContent.onended = contentEndedListener
 
   // Request video ads.
-  const adsRequest = new google.ima.AdsRequest();
-  adsRequest.adTagUrl = adTagUrl;
+  const adsRequest = new google.ima.AdsRequest()
+  adsRequest.adTagUrl = adTagUrl
 
   // Specify the linear and nonlinear slot sizes. This helps the SDK to
   // select the correct creative if multiple are returned.
-  adsRequest.linearAdSlotWidth = 640;
-  adsRequest.linearAdSlotHeight = 400;
+  adsRequest.linearAdSlotWidth = 640
+  adsRequest.linearAdSlotHeight = 400
 
-  adsRequest.nonLinearAdSlotWidth = 640;
-  adsRequest.nonLinearAdSlotHeight = 150;
+  adsRequest.nonLinearAdSlotWidth = 640
+  adsRequest.nonLinearAdSlotHeight = 150
 
-  adsLoader.requestAds(adsRequest);
+  adsLoader.requestAds(adsRequest)
 }
 
 /**
@@ -72,8 +69,7 @@ function setUpIMA(adTagUrl) {
 function createAdDisplayContainer() {
   // We assume the adContainer is the DOM id of the element that will house
   // the ads.
-  adDisplayContainer = new google.ima.AdDisplayContainer(
-      document.getElementById('adContainer'), videoContent);
+  adDisplayContainer = new google.ima.AdDisplayContainer(document.getElementById("adContainer"), videoContent)
 }
 
 /**
@@ -82,20 +78,20 @@ function createAdDisplayContainer() {
 function playAds() {
   // Initialize the container. Must be done through a user action on mobile
   // devices.
-  videoContent.load();
+  videoContent.load()
   if (adDisplayContainer) {
-    adDisplayContainer.initialize();
+    adDisplayContainer.initialize()
   }
 
   try {
     // Initialize the ads manager. Ad rules playlist will start at this time.
-    adsManager.init(640, 360, google.ima.ViewMode.NORMAL);
+    adsManager.init(640, 360, google.ima.ViewMode.NORMAL)
     // Call play to start showing the ad. Single video and overlay ads will
     // start at this time; the call will be ignored for ad rules.
-    adsManager.start();
+    adsManager.start()
   } catch (adError) {
     // An error may be thrown if there was a problem with the VAST response.
-    videoContent.play();
+    videoContent.play()
   }
 }
 
@@ -105,27 +101,22 @@ function playAds() {
  */
 function onAdsManagerLoaded(adsManagerLoadedEvent) {
   // Get the ads manager.
-  const adsRenderingSettings = new google.ima.AdsRenderingSettings();
-  adsRenderingSettings.restoreCustomPlaybackStateOnAdBreakComplete = true;
+  const adsRenderingSettings = new google.ima.AdsRenderingSettings()
+  adsRenderingSettings.restoreCustomPlaybackStateOnAdBreakComplete = true
   // videoContent should be set to the content video element.
-  adsManager =
-      adsManagerLoadedEvent.getAdsManager(videoContent, adsRenderingSettings);
+  adsManager = adsManagerLoadedEvent.getAdsManager(videoContent, adsRenderingSettings)
 
   // Add listeners to the required events.
-  adsManager.addEventListener(google.ima.AdErrorEvent.Type.AD_ERROR, onAdError);
-  adsManager.addEventListener(
-      google.ima.AdEvent.Type.CONTENT_PAUSE_REQUESTED, onContentPauseRequested);
-  adsManager.addEventListener(
-      google.ima.AdEvent.Type.CONTENT_RESUME_REQUESTED,
-      onContentResumeRequested);
-  adsManager.addEventListener(
-      google.ima.AdEvent.Type.ALL_ADS_COMPLETED, onAdEvent);
+  adsManager.addEventListener(google.ima.AdErrorEvent.Type.AD_ERROR, onAdError)
+  adsManager.addEventListener(google.ima.AdEvent.Type.CONTENT_PAUSE_REQUESTED, onContentPauseRequested)
+  adsManager.addEventListener(google.ima.AdEvent.Type.CONTENT_RESUME_REQUESTED, onContentResumeRequested)
+  adsManager.addEventListener(google.ima.AdEvent.Type.ALL_ADS_COMPLETED, onAdEvent)
 
   // Listen to any additional events, if necessary.
-  adsManager.addEventListener(google.ima.AdEvent.Type.LOADED, onAdEvent);
-  adsManager.addEventListener(google.ima.AdEvent.Type.STARTED, onAdEvent);
-  adsManager.addEventListener(google.ima.AdEvent.Type.COMPLETE, onAdEvent);
-  console.log('Ads Manager loaded.')
+  adsManager.addEventListener(google.ima.AdEvent.Type.LOADED, onAdEvent)
+  adsManager.addEventListener(google.ima.AdEvent.Type.STARTED, onAdEvent)
+  adsManager.addEventListener(google.ima.AdEvent.Type.COMPLETE, onAdEvent)
+  console.log("Ads Manager loaded.")
 }
 
 /**
@@ -135,7 +126,7 @@ function onAdsManagerLoaded(adsManagerLoadedEvent) {
 function onAdEvent(adEvent) {
   // Retrieve the ad from the event. Some events (for example,
   // ALL_ADS_COMPLETED) don't have ad object associated.
-  const ad = adEvent.getAd();
+  const ad = adEvent.getAd()
   switch (adEvent.type) {
     case google.ima.AdEvent.Type.LOADED:
       // This is the first event sent for an ad - it is possible to
@@ -143,9 +134,9 @@ function onAdEvent(adEvent) {
       if (!ad.isLinear()) {
         // Position AdDisplayContainer correctly for overlay.
         // Use ad.width and ad.height.
-        videoContent.play();
+        videoContent.play()
       }
-      break;
+      break
     case google.ima.AdEvent.Type.STARTED:
       // This event indicates the ad has started - the video player
       // can adjust the UI, for example display a pause button and
@@ -153,21 +144,19 @@ function onAdEvent(adEvent) {
       if (ad.isLinear()) {
         // For a linear ad, a timer can be started to poll for
         // the remaining time.
-        intervalTimer = setInterval(
-            function() {
-              // Example: const remainingTime = adsManager.getRemainingTime();
-            },
-            300);  // every 300ms
+        intervalTimer = setInterval(function () {
+          // Example: const remainingTime = adsManager.getRemainingTime();
+        }, 300) // every 300ms
       }
-      break;
+      break
     case google.ima.AdEvent.Type.COMPLETE:
       // This event indicates the ad has finished - the video player
       // can perform appropriate UI actions, such as removing the timer for
       // remaining time detection.
       if (ad.isLinear()) {
-        clearInterval(intervalTimer);
+        clearInterval(intervalTimer)
       }
-      break;
+      break
   }
 }
 
@@ -177,16 +166,16 @@ function onAdEvent(adEvent) {
  */
 function onAdError(adErrorEvent) {
   // Handle the error logging.
-  console.log(adErrorEvent.getError());
-  adsManager.destroy();
+  console.log(adErrorEvent.getError())
+  adsManager.destroy()
 }
 
 /**
  * Pauses video content and sets up ad UI.
  */
 function onContentPauseRequested() {
-  isAdPlaying = true;
-  videoContent.pause();
+  isAdPlaying = true
+  videoContent.pause()
   // This function is where you should setup UI for showing ads (for example,
   // display ad timer countdown, disable seeking and more.)
   // setupUIForAds();
@@ -196,9 +185,9 @@ function onContentPauseRequested() {
  * Resumes video content and removes ad UI.
  */
 function onContentResumeRequested() {
-  isAdPlaying = false;
+  isAdPlaying = false
   if (!isContentFinished) {
-    videoContent.play();
+    videoContent.play()
   }
   // This function is where you should ensure that your UI is ready
   // to play content. It is the responsibility of the Publisher to
@@ -206,4 +195,4 @@ function onContentResumeRequested() {
   // setupUIForContent();
 }
 
-init();
+init()

--- a/services/news/tsconfig.json
+++ b/services/news/tsconfig.json
@@ -8,7 +8,5 @@
     "strict": true,
     "skipLibCheck": true
   },
-  "exclude": [
-    "src/public",
-  ],
+  "exclude": ["src/public"]
 }

--- a/services/shop/src/env.js
+++ b/services/shop/src/env.js
@@ -1,6 +1,6 @@
-export const PORT = process.env.PORT || 3000;
-export const EXTERNAL_PORT = process.env.EXTERNAL_PORT || 3000;
-export const SHOP_HOST = process.env.SHOP_HOST || "SHOP_HOST";
-export const SHOP_DETAIL = process.env.SHOP_DETAIL || "SHOP_DETAIL";
-export const SSP_HOST = process.env.SSP_HOST || "localhost";
-export const DSP_HOST = process.env.DSP_HOST || "localhost";
+export const PORT = process.env.PORT || 3000
+export const EXTERNAL_PORT = process.env.EXTERNAL_PORT || 3000
+export const SHOP_HOST = process.env.SHOP_HOST || "SHOP_HOST"
+export const SHOP_DETAIL = process.env.SHOP_DETAIL || "SHOP_DETAIL"
+export const SSP_HOST = process.env.SSP_HOST || "localhost"
+export const DSP_HOST = process.env.DSP_HOST || "localhost"

--- a/services/shop/src/index.js
+++ b/services/shop/src/index.js
@@ -74,6 +74,14 @@ app.get("/", async (req, res) => {
     items
   })
 })
+// serves the static ads creative from shop site (redirected from ssp)
+app.get("/ads/:id", async (req, res) => {
+  const id = req.params.id
+  const imgPath = `/image/svg/emoji_u${id}.svg`
+  //res.set("Content-Type", "image/svg+xml")
+  console.log(`redirecting to /image/svg/emoji_u${id}.svg`)
+  res.redirect(301, imgPath)
+})
 app.get("/items/:id", async (req, res) => {
   const { id } = req.params
   const item = await getItem(id)

--- a/services/shop/src/index.ts
+++ b/services/shop/src/index.ts
@@ -90,6 +90,15 @@ app.get("/", async (req: Request, res: Response) => {
   })
 })
 
+// serves the static ads creative from shop site (redirected from ssp)
+app.get("/ads/:id", async (req: Request, res: Response) => {
+  const id = req.params.id
+  const imgPath = `/image/svg/emoji_u${id}.svg`
+  //res.set("Content-Type", "image/svg+xml")
+  console.log(`redirecting to /image/svg/emoji_u${id}.svg`)
+  res.redirect(301, imgPath)
+})
+
 app.get("/items/:id", async (req: Request, res: Response) => {
   const { id } = req.params
   const item = await getItem(id)

--- a/services/shop/src/lib/items.js
+++ b/services/shop/src/lib/items.js
@@ -14,62 +14,61 @@
  limitations under the License.
  */
 const items = [
-    { id: "1f45e", icon: "👞", price: 180, category: 1, name: "Man's Shoe" },
-    { id: "1f45f", icon: "👟", price: 100, category: 0, name: "Running Shoe" },
-    { id: "1f460", icon: "👠", price: 200, category: 1, name: "High-Heeled Shoe" },
-    { id: "1f461", icon: "👡", price: 120, category: 0, name: "Woman's Sandal" },
-    { id: "1f462", icon: "👢", price: 400, category: 1, name: "Woman's Boot" },
-    { id: "1f6fc", icon: "🛼", price: 230, category: 2, name: "Roller Skate" },
-    { id: "1f97e", icon: "🥾", price: 210, category: 2, name: "Hiking Boot" },
-    { id: "1f97f", icon: "🥿", price: 140, category: 0, name: "Flat Shoe" },
-    { id: "1fa70", icon: "🩰", price: 900, category: 2, name: "Ballet Shoes" },
-    { id: "1fa74", icon: "🩴", price: 12, category: 0, name: "Thong Sandal" },
-    { id: "1f3bf", icon: "🎿", price: 1120, category: 2, name: "Ski Boots" },
-    { id: "26f8", icon: "⛸", price: 1200, category: 2, name: "Ice Skate" }
-];
-export const CATEGORIES = ["sale", "luxury", "sports"];
+  { id: "1f45e", icon: "👞", price: 180, category: 1, name: "Man's Shoe" },
+  { id: "1f45f", icon: "👟", price: 100, category: 0, name: "Running Shoe" },
+  { id: "1f460", icon: "👠", price: 200, category: 1, name: "High-Heeled Shoe" },
+  { id: "1f461", icon: "👡", price: 120, category: 0, name: "Woman's Sandal" },
+  { id: "1f462", icon: "👢", price: 400, category: 1, name: "Woman's Boot" },
+  { id: "1f6fc", icon: "🛼", price: 230, category: 2, name: "Roller Skate" },
+  { id: "1f97e", icon: "🥾", price: 210, category: 2, name: "Hiking Boot" },
+  { id: "1f97f", icon: "🥿", price: 140, category: 0, name: "Flat Shoe" },
+  { id: "1fa70", icon: "🩰", price: 900, category: 2, name: "Ballet Shoes" },
+  { id: "1fa74", icon: "🩴", price: 12, category: 0, name: "Thong Sandal" },
+  { id: "1f3bf", icon: "🎿", price: 1120, category: 2, name: "Ski Boots" },
+  { id: "26f8", icon: "⛸", price: 1200, category: 2, name: "Ice Skate" }
+]
+export const CATEGORIES = ["sale", "luxury", "sports"]
 export async function getItems() {
-    return items;
+  return items
 }
 export async function getItem(id) {
-    return items.find((item) => {
-        return item.id === id;
-    });
+  return items.find((item) => {
+    return item.id === id
+  })
 }
 export function displayCategory(id) {
-    return CATEGORIES.at(id) || "N/A";
+  return CATEGORIES.at(id) || "N/A"
 }
 export function toSize(num) {
-    return `${num / 10 + 20}`;
+  return `${num / 10 + 20}`
 }
 export function fromSize(size) {
-    return (Number(size) - 20) * 10;
+  return (Number(size) - 20) * 10
 }
 export const addOrder = (order, state) => {
-    const index = state.findIndex(({ item, size }) => {
-        return order.item.id === item.id && order.size === size;
-    });
-    if (index > -1) {
-        // increase quantity
-        const current = state.at(index);
-        const next = { ...order, quantity: order.quantity + current.quantity };
-        return [next, ...state.slice(0, index), ...state.slice(index + 1)];
-    }
-    // append
-    return [order, ...state];
-};
+  const index = state.findIndex(({ item, size }) => {
+    return order.item.id === item.id && order.size === size
+  })
+  if (index > -1) {
+    // increase quantity
+    const current = state.at(index)
+    const next = { ...order, quantity: order.quantity + current.quantity }
+    return [next, ...state.slice(0, index), ...state.slice(index + 1)]
+  }
+  // append
+  return [order, ...state]
+}
 export const removeOrder = (order, state) => {
-    return state.reduce((acc, o) => {
-        if (o.item.id === order.item.id && o.size === order.size)
-            return acc;
-        return [...acc, o];
-    }, []);
-};
+  return state.reduce((acc, o) => {
+    if (o.item.id === order.item.id && o.size === order.size) return acc
+    return [...acc, o]
+  }, [])
+}
 export const updateOrder = (order, state) => {
-    return state.reduce((acc, o) => {
-        if (order.item.id === o.item.id && order.size === o.size) {
-            return [...acc, order];
-        }
-        return [...acc, o];
-    }, []);
-};
+  return state.reduce((acc, o) => {
+    if (order.item.id === o.item.id && order.size === o.size) {
+      return [...acc, order]
+    }
+    return [...acc, o]
+  }, [])
+}

--- a/services/shop/src/public/css/global.css
+++ b/services/shop/src/public/css/global.css
@@ -38,7 +38,7 @@
 
 ::before,
 ::after {
-  --tw-content: '';
+  --tw-content: "";
 }
 
 /*
@@ -58,9 +58,10 @@ html {
   -moz-tab-size: 4;
   /* 3 */
   -o-tab-size: 4;
-     tab-size: 4;
+  tab-size: 4;
   /* 3 */
-  font-family: ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji";
+  font-family: ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif,
+    "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji";
   /* 4 */
   font-feature-settings: normal;
   /* 5 */
@@ -101,7 +102,7 @@ Add the correct text decoration in Chrome, Edge, and Safari.
 
 abbr:where([title]) {
   -webkit-text-decoration: underline dotted;
-          text-decoration: underline dotted;
+  text-decoration: underline dotted;
 }
 
 /*
@@ -240,9 +241,9 @@ select {
 */
 
 button,
-[type='button'],
-[type='reset'],
-[type='submit'] {
+[type="button"],
+[type="reset"],
+[type="submit"] {
   -webkit-appearance: button;
   /* 1 */
   background-color: transparent;
@@ -289,7 +290,7 @@ Correct the cursor style of increment and decrement buttons in Safari.
 2. Correct the outline style in Safari.
 */
 
-[type='search'] {
+[type="search"] {
   -webkit-appearance: textfield;
   /* 1 */
   outline-offset: -2px;
@@ -382,7 +383,8 @@ textarea {
 2. Set the default placeholder color to the user's configured gray 400 color.
 */
 
-input::-moz-placeholder, textarea::-moz-placeholder {
+input::-moz-placeholder,
+textarea::-moz-placeholder {
   opacity: 1;
   /* 1 */
   color: #9ca3af;
@@ -450,7 +452,9 @@ video {
   display: none;
 }
 
-*, ::before, ::after {
+*,
+::before,
+::after {
   --tw-border-spacing-x: 0;
   --tw-border-spacing-y: 0;
   --tw-translate-x: 0;
@@ -460,19 +464,19 @@ video {
   --tw-skew-y: 0;
   --tw-scale-x: 1;
   --tw-scale-y: 1;
-  --tw-pan-x:  ;
-  --tw-pan-y:  ;
-  --tw-pinch-zoom:  ;
+  --tw-pan-x: ;
+  --tw-pan-y: ;
+  --tw-pinch-zoom: ;
   --tw-scroll-snap-strictness: proximity;
-  --tw-gradient-from-position:  ;
-  --tw-gradient-via-position:  ;
-  --tw-gradient-to-position:  ;
-  --tw-ordinal:  ;
-  --tw-slashed-zero:  ;
-  --tw-numeric-figure:  ;
-  --tw-numeric-spacing:  ;
-  --tw-numeric-fraction:  ;
-  --tw-ring-inset:  ;
+  --tw-gradient-from-position: ;
+  --tw-gradient-via-position: ;
+  --tw-gradient-to-position: ;
+  --tw-ordinal: ;
+  --tw-slashed-zero: ;
+  --tw-numeric-figure: ;
+  --tw-numeric-spacing: ;
+  --tw-numeric-fraction: ;
+  --tw-ring-inset: ;
   --tw-ring-offset-width: 0px;
   --tw-ring-offset-color: #fff;
   --tw-ring-color: rgb(59 130 246 / 0.5);
@@ -480,24 +484,24 @@ video {
   --tw-ring-shadow: 0 0 #0000;
   --tw-shadow: 0 0 #0000;
   --tw-shadow-colored: 0 0 #0000;
-  --tw-blur:  ;
-  --tw-brightness:  ;
-  --tw-contrast:  ;
-  --tw-grayscale:  ;
-  --tw-hue-rotate:  ;
-  --tw-invert:  ;
-  --tw-saturate:  ;
-  --tw-sepia:  ;
-  --tw-drop-shadow:  ;
-  --tw-backdrop-blur:  ;
-  --tw-backdrop-brightness:  ;
-  --tw-backdrop-contrast:  ;
-  --tw-backdrop-grayscale:  ;
-  --tw-backdrop-hue-rotate:  ;
-  --tw-backdrop-invert:  ;
-  --tw-backdrop-opacity:  ;
-  --tw-backdrop-saturate:  ;
-  --tw-backdrop-sepia:  ;
+  --tw-blur: ;
+  --tw-brightness: ;
+  --tw-contrast: ;
+  --tw-grayscale: ;
+  --tw-hue-rotate: ;
+  --tw-invert: ;
+  --tw-saturate: ;
+  --tw-sepia: ;
+  --tw-drop-shadow: ;
+  --tw-backdrop-blur: ;
+  --tw-backdrop-brightness: ;
+  --tw-backdrop-contrast: ;
+  --tw-backdrop-grayscale: ;
+  --tw-backdrop-hue-rotate: ;
+  --tw-backdrop-invert: ;
+  --tw-backdrop-opacity: ;
+  --tw-backdrop-saturate: ;
+  --tw-backdrop-sepia: ;
 }
 
 ::backdrop {
@@ -510,19 +514,19 @@ video {
   --tw-skew-y: 0;
   --tw-scale-x: 1;
   --tw-scale-y: 1;
-  --tw-pan-x:  ;
-  --tw-pan-y:  ;
-  --tw-pinch-zoom:  ;
+  --tw-pan-x: ;
+  --tw-pan-y: ;
+  --tw-pinch-zoom: ;
   --tw-scroll-snap-strictness: proximity;
-  --tw-gradient-from-position:  ;
-  --tw-gradient-via-position:  ;
-  --tw-gradient-to-position:  ;
-  --tw-ordinal:  ;
-  --tw-slashed-zero:  ;
-  --tw-numeric-figure:  ;
-  --tw-numeric-spacing:  ;
-  --tw-numeric-fraction:  ;
-  --tw-ring-inset:  ;
+  --tw-gradient-from-position: ;
+  --tw-gradient-via-position: ;
+  --tw-gradient-to-position: ;
+  --tw-ordinal: ;
+  --tw-slashed-zero: ;
+  --tw-numeric-figure: ;
+  --tw-numeric-spacing: ;
+  --tw-numeric-fraction: ;
+  --tw-ring-inset: ;
   --tw-ring-offset-width: 0px;
   --tw-ring-offset-color: #fff;
   --tw-ring-color: rgb(59 130 246 / 0.5);
@@ -530,24 +534,24 @@ video {
   --tw-ring-shadow: 0 0 #0000;
   --tw-shadow: 0 0 #0000;
   --tw-shadow-colored: 0 0 #0000;
-  --tw-blur:  ;
-  --tw-brightness:  ;
-  --tw-contrast:  ;
-  --tw-grayscale:  ;
-  --tw-hue-rotate:  ;
-  --tw-invert:  ;
-  --tw-saturate:  ;
-  --tw-sepia:  ;
-  --tw-drop-shadow:  ;
-  --tw-backdrop-blur:  ;
-  --tw-backdrop-brightness:  ;
-  --tw-backdrop-contrast:  ;
-  --tw-backdrop-grayscale:  ;
-  --tw-backdrop-hue-rotate:  ;
-  --tw-backdrop-invert:  ;
-  --tw-backdrop-opacity:  ;
-  --tw-backdrop-saturate:  ;
-  --tw-backdrop-sepia:  ;
+  --tw-blur: ;
+  --tw-brightness: ;
+  --tw-contrast: ;
+  --tw-grayscale: ;
+  --tw-hue-rotate: ;
+  --tw-invert: ;
+  --tw-saturate: ;
+  --tw-sepia: ;
+  --tw-drop-shadow: ;
+  --tw-backdrop-blur: ;
+  --tw-backdrop-brightness: ;
+  --tw-backdrop-contrast: ;
+  --tw-backdrop-grayscale: ;
+  --tw-backdrop-hue-rotate: ;
+  --tw-backdrop-invert: ;
+  --tw-backdrop-opacity: ;
+  --tw-backdrop-saturate: ;
+  --tw-backdrop-sepia: ;
 }
 
 .absolute {
@@ -687,12 +691,12 @@ video {
 
 .object-cover {
   -o-object-fit: cover;
-     object-fit: cover;
+  object-fit: cover;
 }
 
 .object-\[0\%_5\%\] {
   -o-object-position: 0% 5%;
-     object-position: 0% 5%;
+  object-position: 0% 5%;
 }
 
 .px-2 {
@@ -824,7 +828,7 @@ body {
 }
 
 .before\:content-\[\'\<\<\'\]::before {
-  --tw-content: '<<';
+  --tw-content: "<<";
   content: var(--tw-content);
 }
 

--- a/services/shop/src/public/js/cart.js
+++ b/services/shop/src/public/js/cart.js
@@ -18,7 +18,6 @@ const $ = document.querySelector.bind(document)
 const $$ = document.querySelectorAll.bind(document)
 EventTarget.prototype.on = EventTarget.prototype.addEventListener
 
-
 document.on("DOMContentLoaded", async (e) => {
   $$(".remove-item").forEach(($button) => {
     $button.on("click", async (e) => {

--- a/services/ssp/package-lock.json
+++ b/services/ssp/package-lock.json
@@ -11,7 +11,8 @@
       "dependencies": {
         "cbor": "^9.0.0",
         "ejs": "^3.1.9",
-        "express": "^4.18.2"
+        "express": "^4.18.2",
+        "structured-field-values": "^2.0.1"
       },
       "devDependencies": {
         "prettier": "^3.0.0"
@@ -728,6 +729,11 @@
       "engines": {
         "node": ">= 0.8"
       }
+    },
+    "node_modules/structured-field-values": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/structured-field-values/-/structured-field-values-2.0.1.tgz",
+      "integrity": "sha512-1VNk582THEQbA6X7pZF+0mjTH8jD1lvckzZx5gzUW3F6m0Bqi5EJ/WnM4S0egNz+KdKII7A8ArRCqMafZWh7pQ=="
     },
     "node_modules/supports-color": {
       "version": "7.2.0",

--- a/services/ssp/package.json
+++ b/services/ssp/package.json
@@ -11,7 +11,8 @@
   "dependencies": {
     "cbor": "^9.0.0",
     "ejs": "^3.1.9",
-    "express": "^4.18.2"
+    "express": "^4.18.2",
+    "structured-field-values": "^2.0.1"
   },
   "devDependencies": {
     "prettier": "^3.0.0"

--- a/services/ssp/src/index.js
+++ b/services/ssp/src/index.js
@@ -18,6 +18,7 @@
 import express from "express"
 import url from "url"
 import cbor from "cbor"
+import { decodeDict } from "structured-field-values"
 import {
   debugKey,
   sourceEventId,
@@ -113,10 +114,11 @@ app.get("/register-source", async (req, res) => {
   const { advertiser, id } = req.query
   console.log("Registering source attribution for", { advertiser, id })
   if (req.headers["attribution-reporting-eligible"]) {
-    const are = req.headers["attribution-reporting-eligible"].split(",").map((e) => e.trim())
+    //const are = req.headers["attribution-reporting-eligible"].split(",").map((e) => e.trim())
+    const are = decodeDict(req.headers["attribution-reporting-eligible"])
 
     // register navigation source
-    if (are.includes("navigation-source")) {
+    if ("navigation-source" in are) {
       const destination = `https://${advertiser}`
       const source_event_id = sourceEventId()
       const debug_key = debugKey()
@@ -148,7 +150,7 @@ app.get("/register-source", async (req, res) => {
     }
 
     // register event source
-    else if (are.includes("event-source") && are.includes("trigger")) {
+    else if ("event-source" in are) {
       const destination = `https://${advertiser}`
       const source_event_id = sourceEventId()
       const debug_key = debugKey()

--- a/services/ssp/src/index.js
+++ b/services/ssp/src/index.js
@@ -183,7 +183,7 @@ app.get("/creative", async (req, res) => {
   }
 
   // redirect to advertisers Ads endpoint
-  res.redirect(`https://${advertiser}/api/ads/${id}`)
+  res.redirect(`https://${advertiser}/ads/${id}`)
 })
 
 app.get("/register-trigger", async (req, res) => {

--- a/services/ssp/src/public/js/run-video-ad-auction.js
+++ b/services/ssp/src/public/js/run-video-ad-auction.js
@@ -16,16 +16,16 @@
 
 async function getAuctionConfig() {
   const url = new URL(location.origin)
-  url.pathname = '/auction-config.json'
+  url.pathname = "/auction-config.json"
   const res = await fetch(url)
   if (res.ok) {
     return res.json()
   }
 }
 
-document.addEventListener('DOMContentLoaded', async () => {
+document.addEventListener("DOMContentLoaded", async () => {
   if (navigator.runAdAuction === undefined) {
-    return console.log('[DEMO] Protected Audience API is not supported')
+    return console.log("[DEMO] Protected Audience API is not supported")
   }
   const auctionConfig = await getAuctionConfig()
   // FencedFrameConfing can't be rendered in iframes.
@@ -34,8 +34,8 @@ document.addEventListener('DOMContentLoaded', async () => {
   const adAuctionResult = await navigator.runAdAuction(auctionConfig)
   console.log({ auctionConfig, adAuctionResult })
   if (adAuctionResult) {
-    const adFrame = document.createElement('iframe')
-    adFrame.id = 'video-ad-frame'
+    const adFrame = document.createElement("iframe")
+    adFrame.id = "video-ad-frame"
     adFrame.src = adAuctionResult
     adFrame.width = 0
     adFrame.height = 0

--- a/services/ssp/src/public/js/video-ad-tag.js
+++ b/services/ssp/src/public/js/video-ad-tag.js
@@ -14,23 +14,22 @@
  limitations under the License.
 */
 
-
-(async () => {
-    const ins = document.querySelector('ins.ads')
-    const script = document.querySelector('.ssp_tag')
-    const src = new URL(script.src)
-    src.pathname = '/video-ad-tag.html'
-    const iframe = document.createElement('iframe')
-    iframe.width = 0
-    iframe.height = 0
-    iframe.src = src
-    iframe.setAttribute('allow', 'attribution-reporting; run-ad-auction')
-    ins.appendChild(iframe)
+;(async () => {
+  const ins = document.querySelector("ins.ads")
+  const script = document.querySelector(".ssp_tag")
+  const src = new URL(script.src)
+  src.pathname = "/video-ad-tag.html"
+  const iframe = document.createElement("iframe")
+  iframe.width = 0
+  iframe.height = 0
+  iframe.src = src
+  iframe.setAttribute("allow", "attribution-reporting; run-ad-auction")
+  ins.appendChild(iframe)
 })()
 
-window.addEventListener('message', (event) => {
-    if (!event.origin.startsWith('https://privacy-sandbox-demos-dsp')) return
-    if (typeof event.data !== 'string') return
-    const {adVastUrl} = JSON.parse(event.data)
-    setUpIMA(adVastUrl)
+window.addEventListener("message", (event) => {
+  if (!event.origin.startsWith("https://privacy-sandbox-demos-dsp")) return
+  if (typeof event.data !== "string") return
+  const { adVastUrl } = JSON.parse(event.data)
+  setUpIMA(adVastUrl)
 })

--- a/services/ssp/src/views/ads.html.ejs
+++ b/services/ssp/src/views/ads.html.ejs
@@ -3,9 +3,14 @@
 
 <head>
   <meta charset="UTF-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title><%= title %></title>
-  <link rel="icon" href="" />
+  <meta name="viewport"
+        content="width=device-width, initial-scale=1.0" />
+  <title>
+    <%= title
+        %>
+  </title>
+  <link rel="icon"
+        href="" />
   <style>
     body {
       width: 100vw;
@@ -22,9 +27,19 @@
 </head>
 
 <body>
-  <a width="300" height="250" target="_blank" attributionsrc href="<%= move %>">
+  <a width="300"
+     height="250"
+     target="_blank"
+     attributionsrc="<%= registerSource %>"
+     href="<%= move %>">
     <!-- smaller for avoid scrollbar -->
-    <img width="294" height="245" loading="lazy" attributionsrc src="<%= creative %>">
+    <img width="294"
+         height="245"
+         loading="lazy"
+         attributionsrc="<%= registerSource %>""
+         src="
+         <%=creative
+         %>">
   </a>
 </body>
 

--- a/services/ssp/src/views/ads.html.ejs
+++ b/services/ssp/src/views/ads.html.ejs
@@ -36,7 +36,7 @@
     <img width="294"
          height="245"
          loading="lazy"
-         attributionsrc="<%= registerSource %>""
+         attributionsrc="<%= registerSource %>"
          src="
          <%=creative
          %>">


### PR DESCRIPTION
# Description

- Fix ads endpoint missing on SSP service (ad creative could not be displayed on publisher site)
- FIx [Registering attribution sources](https://github.com/WICG/attribution-reporting-api/blob/main/EVENT.md#registering-attribution-sources) : "Attribution-Reporting-Eligible" is a [Dictionary Structured Header](https://httpwg.org/specs/rfc8941.html#dictionary) and thus needed to be decoded properly. https://wicg.github.io/attribution-reporting-api/#issue-8fc7b5a1
- Fix remarketing use case documentation
- Fix single touch conversion attribution use case documentation


## Related Issue



## Affected services

- [ x] Home
- [ ] News
- [ ] Shop
- [ ] Travel
- [ ] DSP
- [x] SSP
- [ ] ALL

Other:
- run fmt on project files
- fix npm run clean commad