### PR TITLE
Update enrollment attestation to v2 format for dsp service

### DIFF
--- a/services/dsp/src/public/.well-known/privacy-sandbox-attestations.json
+++ b/services/dsp/src/public/.well-known/privacy-sandbox-attestations.json
@@ -1,9 +1,48 @@
 {
   "privacy_sandbox_api_attestations": [
     {
+      "attestation_parser_version": "2",
+      "attestation_version": "2",
+      "privacy_policy": [
+        "https://policies.google.com/privacy"
+      ],
+      "ownership_token": "SGYvJieJb5EaxhMAJUh9qmrfZNSQewLYbHWx6NpeRzDLZSF0DwfVfchu5sHCxaFv",
+      "issued_seconds_since_epoch": 1697505143,
+      "enrollment_id": "UNRJE",
+      "enrollment_site": "https://privacy-sandbox-demos-dsp.dev",
+      "platform_attestations": [
+        {
+          "platform": "chrome",
+          "attestations": {
+            "attribution_reporting_api": {
+              "ServiceNotUsedForIdentifyingUserAcrossSites": true
+            },
+            "shared_storage_api": {
+              "ServiceNotUsedForIdentifyingUserAcrossSites": true
+            },
+            "private_aggregation_api": {
+              "ServiceNotUsedForIdentifyingUserAcrossSites": true
+            },
+            "topics_api": {
+              "ServiceNotUsedForIdentifyingUserAcrossSites": true
+            },
+            "protected_audience_api": {
+              "ServiceNotUsedForIdentifyingUserAcrossSites": true
+            }
+          }
+        },
+        {
+          "platform": "android",
+          "attestations": {}
+        }
+      ]
+    },
+    {
       "attestation_parser_version": "1",
       "attestation_version": "1",
-      "privacy_policy": ["https://policies.google.com/privacy"],
+      "privacy_policy": [
+        "https://policies.google.com/privacy"
+      ],
       "ownership_token": "yE67UyEyxUmBsz0y0hyeiU44CnbliMjMS93fnBgeb8Jlst1YbwYXAE5ucVige0eX",
       "issued_seconds_since_epoch": 1691175921,
       "expiry_seconds_since_epoch": 1706731521,


### PR DESCRIPTION
# Description

Update enrollment attestation to v2 format for dsp service

References : 
- https://github.com/privacysandbox/attestation
- https://github.com/privacysandbox/attestation/blob/main/how-to-enroll.md#upload-your-attestation-file
- 
## Related Issue

- NA

## Affected services

- [ ] Home
- [ ] News
- [ ] Shop
- [ ] Travel
- [x] DSP
- [ ] SSP
- [ ] ALL

Other:
