### PR TITLE
Add attestation files v2 for DSP & SSP services

### DIFF
--- a/cicd/attestations/privacy-sandbox-attestations.json.dsp.dev
+++ b/cicd/attestations/privacy-sandbox-attestations.json.dsp.dev
@@ -1,0 +1,41 @@
+{
+  "privacy_sandbox_api_attestations": [
+    {
+      "attestation_parser_version": "2",
+      "attestation_version": "1",
+      "privacy_policy": [
+        "https://policies.google.com/privacy"
+      ],
+      "ownership_token": "nTnUCtbPyTd5O9ev8OlcTRRGz02BYKf2qXRbZ3baiwZy5Pqsss5wOiu6Fi6lv6nT",
+      "issued_seconds_since_epoch": 1698941188,
+      "enrollment_id": "Z7XX7",
+      "enrollment_site": "https://privacy-sandcastle-dev-dsp.web.app/",
+      "platform_attestations": [
+        {
+          "platform": "chrome",
+          "attestations": {
+            "attribution_reporting_api": {
+              "ServiceNotUsedForIdentifyingUserAcrossSites": true
+            },
+            "shared_storage_api": {
+              "ServiceNotUsedForIdentifyingUserAcrossSites": true
+            },
+            "private_aggregation_api": {
+              "ServiceNotUsedForIdentifyingUserAcrossSites": true
+            },
+            "topics_api": {
+              "ServiceNotUsedForIdentifyingUserAcrossSites": true
+            },
+            "protected_audience_api": {
+              "ServiceNotUsedForIdentifyingUserAcrossSites": true
+            }
+          }
+        },
+        {
+          "platform": "android",
+          "attestations": {}
+        }
+      ]
+    }
+  ]
+}

--- a/cicd/attestations/privacy-sandbox-attestations.json.dsp.prod
+++ b/cicd/attestations/privacy-sandbox-attestations.json.dsp.prod
@@ -1,0 +1,78 @@
+{
+  "privacy_sandbox_api_attestations": [
+    {
+      "attestation_parser_version": "2",
+      "attestation_version": "2",
+      "privacy_policy": [
+        "https://policies.google.com/privacy"
+      ],
+      "ownership_token": "SGYvJieJb5EaxhMAJUh9qmrfZNSQewLYbHWx6NpeRzDLZSF0DwfVfchu5sHCxaFv",
+      "issued_seconds_since_epoch": 1697505143,
+      "enrollment_id": "UNRJE",
+      "enrollment_site": "https://privacy-sandbox-demos-dsp.dev",
+      "platform_attestations": [
+        {
+          "platform": "chrome",
+          "attestations": {
+            "attribution_reporting_api": {
+              "ServiceNotUsedForIdentifyingUserAcrossSites": true
+            },
+            "shared_storage_api": {
+              "ServiceNotUsedForIdentifyingUserAcrossSites": true
+            },
+            "private_aggregation_api": {
+              "ServiceNotUsedForIdentifyingUserAcrossSites": true
+            },
+            "topics_api": {
+              "ServiceNotUsedForIdentifyingUserAcrossSites": true
+            },
+            "protected_audience_api": {
+              "ServiceNotUsedForIdentifyingUserAcrossSites": true
+            }
+          }
+        },
+        {
+          "platform": "android",
+          "attestations": {}
+        }
+      ]
+    },
+    {
+      "attestation_parser_version": "1",
+      "attestation_version": "1",
+      "privacy_policy": [
+        "https://policies.google.com/privacy"
+      ],
+      "ownership_token": "yE67UyEyxUmBsz0y0hyeiU44CnbliMjMS93fnBgeb8Jlst1YbwYXAE5ucVige0eX",
+      "issued_seconds_since_epoch": 1691175921,
+      "expiry_seconds_since_epoch": 1706731521,
+      "enrollment_id": "UNRJE",
+      "platform_attestations": [
+        {
+          "platform": "chrome",
+          "attestations": {
+            "attribution_reporting_api": {
+              "ServiceNotUsedForReidentification": true
+            },
+            "shared_storage_api": {
+              "ServiceNotUsedForReidentification": true
+            },
+            "private_aggregation_api": {
+              "ServiceNotUsedForReidentification": true
+            },
+            "topics_api": {
+              "ServiceNotUsedForReidentification": true
+            },
+            "protected_audience_api": {
+              "ServiceNotUsedForReidentification": true
+            }
+          }
+        },
+        {
+          "platform": "android",
+          "attestations": {}
+        }
+      ]
+    }
+  ]
+}

--- a/cicd/attestations/privacy-sandbox-attestations.json.ssp.dev
+++ b/cicd/attestations/privacy-sandbox-attestations.json.ssp.dev
@@ -1,0 +1,41 @@
+{
+  "privacy_sandbox_api_attestations": [
+    {
+      "attestation_parser_version": "2",
+      "attestation_version": "1",
+      "privacy_policy": [
+        "https://policies.google.com/privacy"
+      ],
+      "ownership_token": "uNqxzzSkFmSw0tFTnaV2FDl4Ltd0SpOLxI3UMbDhklwBGFQJ8AsQ3XqFqzj8j3ev",
+      "issued_seconds_since_epoch": 1698941002,
+      "enrollment_id": "VV8GR",
+      "enrollment_site": "https://privacy-sandcastle-dev-ssp.web.app/",
+      "platform_attestations": [
+        {
+          "platform": "chrome",
+          "attestations": {
+            "attribution_reporting_api": {
+              "ServiceNotUsedForIdentifyingUserAcrossSites": true
+            },
+            "shared_storage_api": {
+              "ServiceNotUsedForIdentifyingUserAcrossSites": true
+            },
+            "private_aggregation_api": {
+              "ServiceNotUsedForIdentifyingUserAcrossSites": true
+            },
+            "topics_api": {
+              "ServiceNotUsedForIdentifyingUserAcrossSites": true
+            },
+            "protected_audience_api": {
+              "ServiceNotUsedForIdentifyingUserAcrossSites": true
+            }
+          }
+        },
+        {
+          "platform": "android",
+          "attestations": {}
+        }
+      ]
+    }
+  ]
+}

--- a/cicd/attestations/privacy-sandbox-attestations.json.ssp.prod
+++ b/cicd/attestations/privacy-sandbox-attestations.json.ssp.prod
@@ -1,0 +1,41 @@
+{
+  "privacy_sandbox_api_attestations": [
+    {
+      "attestation_parser_version": "2",
+      "attestation_version": "1",
+      "privacy_policy": [
+        "https://policies.google.com/privacy"
+      ],
+      "ownership_token": "Dxf5IH5uGemQA0fyXTsOyiC0lWWtJXpSgA4S0KeUwtpWreWb9vbzeLx6LTuwCNzh",
+      "issued_seconds_since_epoch": 1698941376,
+      "enrollment_id": "EQPDM",
+      "enrollment_site": "https://privacy-sandbox-demos-ssp.dev/",
+      "platform_attestations": [
+        {
+          "platform": "chrome",
+          "attestations": {
+            "attribution_reporting_api": {
+              "ServiceNotUsedForIdentifyingUserAcrossSites": true
+            },
+            "shared_storage_api": {
+              "ServiceNotUsedForIdentifyingUserAcrossSites": true
+            },
+            "private_aggregation_api": {
+              "ServiceNotUsedForIdentifyingUserAcrossSites": true
+            },
+            "topics_api": {
+              "ServiceNotUsedForIdentifyingUserAcrossSites": true
+            },
+            "protected_audience_api": {
+              "ServiceNotUsedForIdentifyingUserAcrossSites": true
+            }
+          }
+        },
+        {
+          "platform": "android",
+          "attestations": {}
+        }
+      ]
+    }
+  ]
+}

--- a/cicd/cloudbuild.yaml
+++ b/cicd/cloudbuild.yaml
@@ -1,4 +1,5 @@
 steps:
+  # Read environment variables we will use to deploy to Cloud Run
   - name: "bash"
     id: read-env
     waitFor: ["-"]
@@ -10,17 +11,29 @@ steps:
       ENV_VARS=$(cat cicd/.env.${PROJECT_ENV} | grep "=" | grep -v "^PORT=" | sed '/^$/d' | tr "\n" "@")
       echo ${ENV_VARS}
       echo ${ENV_VARS} > /workspace/env_vars.txt
+  # Copy the Privacy Sandbox Attestation files for the target environment
+  - name: "bash"
+    id: copy-attestations
+    waitFor: ["-"]
+    env:
+      - "PROJECT_ENV=$_PROJECT_ENV"
+    script: |
+      #!/usr/bin/env bash
+
+      cp -f cicd/attestations/privacy-sandbox-attestations.json.dsp.${PROJECT_ENV} services/dsp/src/public/.well-known/privacy-sandbox-attestations.json
+      cp -f cicd/attestations/privacy-sandbox-attestations.json.ssp.${PROJECT_ENV} services/ssp/src/public/.well-known/privacy-sandbox-attestations.json
   # DSP
   # Build the container image
   - name: "gcr.io/cloud-builders/docker"
     id: build-dsp
-    waitFor: ["-"]
+    waitFor:
+      - copy-attestations
     args:
       [
         "build",
         "-t",
         "${_LOCATION}-docker.pkg.dev/$PROJECT_ID/${_REPOSITORY}/dsp:$COMMIT_SHA",
-        "services/dsp"
+        "services/dsp",
       ]
   # Push the container image to Container Registry
   - name: "gcr.io/cloud-builders/docker"
@@ -30,7 +43,7 @@ steps:
     args:
       [
         "push",
-        "${_LOCATION}-docker.pkg.dev/$PROJECT_ID/${_REPOSITORY}/dsp:$COMMIT_SHA"
+        "${_LOCATION}-docker.pkg.dev/$PROJECT_ID/${_REPOSITORY}/dsp:$COMMIT_SHA",
       ]
   # Deploy container image to Cloud Run
   - name: "gcr.io/cloud-builders/gcloud"
@@ -51,24 +64,13 @@ steps:
     id: npm-install-home
     waitFor: ["-"]
     entrypoint: "npm"
-    args:
-      [
-        "--prefix",
-        "services/home",
-        "install"
-      ]
+    args: ["--prefix", "services/home", "install"]
   - name: "node"
     id: npm-run-build-home
     waitFor:
       - npm-install-home
     entrypoint: "npm"
-    args:
-      [
-        "--prefix",
-        "services/home",
-        "run",
-        "build"
-      ]
+    args: ["--prefix", "services/home", "run", "build"]
   # Build the container image
   - name: "gcr.io/cloud-builders/docker"
     id: build-home
@@ -79,7 +81,7 @@ steps:
         "build",
         "-t",
         "${_LOCATION}-docker.pkg.dev/$PROJECT_ID/${_REPOSITORY}/home:$COMMIT_SHA",
-        "services/home"
+        "services/home",
       ]
   # Push the container image to Container Registry
   - name: "gcr.io/cloud-builders/docker"
@@ -89,7 +91,7 @@ steps:
     args:
       [
         "push",
-        "${_LOCATION}-docker.pkg.dev/$PROJECT_ID/${_REPOSITORY}/home:$COMMIT_SHA"
+        "${_LOCATION}-docker.pkg.dev/$PROJECT_ID/${_REPOSITORY}/home:$COMMIT_SHA",
       ]
   # Deploy container image to Cloud Run
   - name: "gcr.io/cloud-builders/gcloud"
@@ -114,7 +116,7 @@ steps:
         "build",
         "-t",
         "${_LOCATION}-docker.pkg.dev/$PROJECT_ID/${_REPOSITORY}/news:$COMMIT_SHA",
-        "services/news"
+        "services/news",
       ]
   # Push the container image to Container Registry
   - name: "gcr.io/cloud-builders/docker"
@@ -124,7 +126,7 @@ steps:
     args:
       [
         "push",
-        "${_LOCATION}-docker.pkg.dev/$PROJECT_ID/${_REPOSITORY}/news:$COMMIT_SHA"
+        "${_LOCATION}-docker.pkg.dev/$PROJECT_ID/${_REPOSITORY}/news:$COMMIT_SHA",
       ]
   # Deploy container image to Cloud Run
   - name: "gcr.io/cloud-builders/gcloud"
@@ -150,7 +152,7 @@ steps:
         "build",
         "-t",
         "${_LOCATION}-docker.pkg.dev/$PROJECT_ID/${_REPOSITORY}/shop:$COMMIT_SHA",
-        "services/shop"
+        "services/shop",
       ]
   # Push the container image to Container Registry
   - name: "gcr.io/cloud-builders/docker"
@@ -160,7 +162,7 @@ steps:
     args:
       [
         "push",
-        "${_LOCATION}-docker.pkg.dev/$PROJECT_ID/${_REPOSITORY}/shop:$COMMIT_SHA"
+        "${_LOCATION}-docker.pkg.dev/$PROJECT_ID/${_REPOSITORY}/shop:$COMMIT_SHA",
       ]
   # Deploy container image to Cloud Run
   - name: "gcr.io/cloud-builders/gcloud"
@@ -180,13 +182,14 @@ steps:
   # Build the container image
   - name: "gcr.io/cloud-builders/docker"
     id: build-ssp
-    waitFor: ["-"]
+    waitFor:
+      - copy-attestations
     args:
       [
         "build",
         "-t",
         "${_LOCATION}-docker.pkg.dev/$PROJECT_ID/${_REPOSITORY}/ssp:$COMMIT_SHA",
-        "services/ssp"
+        "services/ssp",
       ]
   # Push the container image to Container Registry
   - name: "gcr.io/cloud-builders/docker"
@@ -196,7 +199,7 @@ steps:
     args:
       [
         "push",
-        "${_LOCATION}-docker.pkg.dev/$PROJECT_ID/${_REPOSITORY}/ssp:$COMMIT_SHA"
+        "${_LOCATION}-docker.pkg.dev/$PROJECT_ID/${_REPOSITORY}/ssp:$COMMIT_SHA",
       ]
   # Deploy container image to Cloud Run
   - name: "gcr.io/cloud-builders/gcloud"
@@ -222,7 +225,7 @@ steps:
         "build",
         "-t",
         "${_LOCATION}-docker.pkg.dev/$PROJECT_ID/${_REPOSITORY}/travel:$COMMIT_SHA",
-        "services/travel"
+        "services/travel",
       ]
   # Push the container image to Container Registry
   - name: "gcr.io/cloud-builders/docker"
@@ -232,7 +235,7 @@ steps:
     args:
       [
         "push",
-        "${_LOCATION}-docker.pkg.dev/$PROJECT_ID/${_REPOSITORY}/travel:$COMMIT_SHA"
+        "${_LOCATION}-docker.pkg.dev/$PROJECT_ID/${_REPOSITORY}/travel:$COMMIT_SHA",
       ]
   # Deploy container image to Cloud Run
   - name: "gcr.io/cloud-builders/gcloud"
@@ -258,7 +261,7 @@ steps:
         "build",
         "-t",
         "${_LOCATION}-docker.pkg.dev/$PROJECT_ID/${_REPOSITORY}/topics:$COMMIT_SHA",
-        "services/topics"
+        "services/topics",
       ]
   # Push the container image to Container Registry
   - name: "gcr.io/cloud-builders/docker"
@@ -268,7 +271,7 @@ steps:
     args:
       [
         "push",
-        "${_LOCATION}-docker.pkg.dev/$PROJECT_ID/${_REPOSITORY}/topics:$COMMIT_SHA"
+        "${_LOCATION}-docker.pkg.dev/$PROJECT_ID/${_REPOSITORY}/topics:$COMMIT_SHA",
       ]
   # Deploy container image to Cloud Run
   - name: "gcr.io/cloud-builders/gcloud"
@@ -294,7 +297,7 @@ steps:
         "build",
         "-t",
         "${_LOCATION}-docker.pkg.dev/$PROJECT_ID/${_REPOSITORY}/topics-server:$COMMIT_SHA",
-        "services/topics-server"
+        "services/topics-server",
       ]
   # Push the container image to Container Registry
   - name: "gcr.io/cloud-builders/docker"
@@ -304,7 +307,7 @@ steps:
     args:
       [
         "push",
-        "${_LOCATION}-docker.pkg.dev/$PROJECT_ID/${_REPOSITORY}/topics-server:$COMMIT_SHA"
+        "${_LOCATION}-docker.pkg.dev/$PROJECT_ID/${_REPOSITORY}/topics-server:$COMMIT_SHA",
       ]
   # Deploy container image to Cloud Run
   - name: "gcr.io/cloud-builders/gcloud"

--- a/services/dsp/src/public/.well-known/privacy-sandbox-attestations.json
+++ b/services/dsp/src/public/.well-known/privacy-sandbox-attestations.json
@@ -1,9 +1,48 @@
 {
   "privacy_sandbox_api_attestations": [
     {
+      "attestation_parser_version": "2",
+      "attestation_version": "2",
+      "privacy_policy": [
+        "https://policies.google.com/privacy"
+      ],
+      "ownership_token": "SGYvJieJb5EaxhMAJUh9qmrfZNSQewLYbHWx6NpeRzDLZSF0DwfVfchu5sHCxaFv",
+      "issued_seconds_since_epoch": 1697505143,
+      "enrollment_id": "UNRJE",
+      "enrollment_site": "https://privacy-sandbox-demos-dsp.dev",
+      "platform_attestations": [
+        {
+          "platform": "chrome",
+          "attestations": {
+            "attribution_reporting_api": {
+              "ServiceNotUsedForIdentifyingUserAcrossSites": true
+            },
+            "shared_storage_api": {
+              "ServiceNotUsedForIdentifyingUserAcrossSites": true
+            },
+            "private_aggregation_api": {
+              "ServiceNotUsedForIdentifyingUserAcrossSites": true
+            },
+            "topics_api": {
+              "ServiceNotUsedForIdentifyingUserAcrossSites": true
+            },
+            "protected_audience_api": {
+              "ServiceNotUsedForIdentifyingUserAcrossSites": true
+            }
+          }
+        },
+        {
+          "platform": "android",
+          "attestations": {}
+        }
+      ]
+    },
+    {
       "attestation_parser_version": "1",
       "attestation_version": "1",
-      "privacy_policy": ["https://policies.google.com/privacy"],
+      "privacy_policy": [
+        "https://policies.google.com/privacy"
+      ],
       "ownership_token": "yE67UyEyxUmBsz0y0hyeiU44CnbliMjMS93fnBgeb8Jlst1YbwYXAE5ucVige0eX",
       "issued_seconds_since_epoch": 1691175921,
       "expiry_seconds_since_epoch": 1706731521,

--- a/services/ssp/src/public/.well-known/privacy-sandbox-attestations.json
+++ b/services/ssp/src/public/.well-known/privacy-sandbox-attestations.json
@@ -1,0 +1,41 @@
+{
+  "privacy_sandbox_api_attestations": [
+    {
+      "attestation_parser_version": "2",
+      "attestation_version": "1",
+      "privacy_policy": [
+        "https://policies.google.com/privacy"
+      ],
+      "ownership_token": "Dxf5IH5uGemQA0fyXTsOyiC0lWWtJXpSgA4S0KeUwtpWreWb9vbzeLx6LTuwCNzh",
+      "issued_seconds_since_epoch": 1698941376,
+      "enrollment_id": "EQPDM",
+      "enrollment_site": "https://privacy-sandbox-demos-ssp.dev/",
+      "platform_attestations": [
+        {
+          "platform": "chrome",
+          "attestations": {
+            "attribution_reporting_api": {
+              "ServiceNotUsedForIdentifyingUserAcrossSites": true
+            },
+            "shared_storage_api": {
+              "ServiceNotUsedForIdentifyingUserAcrossSites": true
+            },
+            "private_aggregation_api": {
+              "ServiceNotUsedForIdentifyingUserAcrossSites": true
+            },
+            "topics_api": {
+              "ServiceNotUsedForIdentifyingUserAcrossSites": true
+            },
+            "protected_audience_api": {
+              "ServiceNotUsedForIdentifyingUserAcrossSites": true
+            }
+          }
+        },
+        {
+          "platform": "android",
+          "attestations": {}
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
# Description

- Add Enrollment and Attestation files for dev and prod environment deployment
- Update Cloud Build configuration so copy attestation files for the target environment (dev or prod)

## Affected services

- [ ] Home
- [ ] News
- [ ] Shop
- [ ] Travel
- [x] DSP
- [x] SSP
- [ ] ALL

Other:
- CI/CD