### PR TITLE
fixes multi-seller-auction demo to run both on docker & cloud run

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,6 +21,7 @@ services:
     image: gcr.io/privacy-sandbox-demos/home:latest
     build: ./services/home
     container_name: "sandcastle_home"
+    hostname: ${HOME_HOST:?err}
     env_file:
       - .env
     networks:
@@ -30,6 +31,7 @@ services:
     image: gcr.io/privacy-sandbox-demos/news:latest
     build: ./services/news
     container_name: "sandcastle_news"
+    hostname: ${NEWS_HOST:?err}
     env_file:
       - .env
     volumes:
@@ -42,6 +44,7 @@ services:
     image: gcr.io/privacy-sandbox-demos/shop:latest
     build: ./services/shop
     container_name: "sandcastle_shop"
+    hostname: ${SHOP_HOST:?err}
     env_file:
       - .env
     volumes:
@@ -54,6 +57,7 @@ services:
     image: gcr.io/privacy-sandbox-demos/travel:latest
     build: ./services/travel
     container_name: "sandcastle_travel"
+    hostname: ${TRAVEL_HOST:?err}
     env_file:
       - .env
     volumes:
@@ -66,6 +70,7 @@ services:
     image: gcr.io/privacy-sandbox-demos/dsp:latest
     build: ./services/dsp
     container_name: "sandcastle_dsp"
+    hostname: ${DSP_HOST:?err}
     env_file:
       - .env
     volumes:
@@ -78,6 +83,7 @@ services:
     image: gcr.io/privacy-sandbox-demos/dsp-a:latest
     build: ./services/dsp-a
     container_name: "sandcastle_dsp_a"
+    hostname: ${DSP_A_HOST:?err}
     env_file:
       - .env
     volumes:
@@ -90,6 +96,7 @@ services:
     image: gcr.io/privacy-sandbox-demos/dsp-b:latest
     build: ./services/dsp-b
     container_name: "sandcastle_dsp_b"
+    hostname: ${DSP_B_HOST:?err}
     env_file:
       - .env
     volumes:
@@ -102,6 +109,7 @@ services:
     image: gcr.io/privacy-sandbox-demos/ssp:latest
     build: ./services/ssp
     container_name: "sandcastle_ssp"
+    hostname: ${SSP_HOST:?err}
     env_file:
       - .env
     volumes:
@@ -114,6 +122,7 @@ services:
     image: gcr.io/privacy-sandbox-demos/ssp-a:latest
     build: ./services/ssp-a
     container_name: "sandcastle_ssp_a"
+    hostname: ${SSP_A_HOST:?err}
     env_file:
       - .env
     volumes:
@@ -126,6 +135,7 @@ services:
     image: gcr.io/privacy-sandbox-demos/ssp-b:latest
     build: ./services/ssp-b
     container_name: "sandcastle_ssp_b"
+    hostname: ${SSP_B_HOST:?err}
     env_file:
       - .env
     volumes:
@@ -134,10 +144,24 @@ services:
     networks:
       - adnetwork
 
+  ad-server:
+    image: gcr.io/privacy-sandbox-demos/ad-server:latest
+    build: ./services/ad-server
+    container_name: "sandcastle_ad_server"
+    hostname: ${AD_SERVER_HOST:?err}
+    env_file:
+      - .env
+    volumes:
+      - ./services/ad-server:/workspace
+      - ad_server_node_modules:/workspace/node_modules
+    networks:
+      - adnetwork
+
   collector:
     image: gcr.io/privacy-sandbox-demos/collector:latest
     build: ./services/collector
     container_name: "sandcastle_collector"
+    hostname: ${COLLECTOR_HOST:?err}
     env_file:
       - .env
     volumes:
@@ -161,23 +185,12 @@ services:
     image: gcr.io/privacy-sandbox-demos/topics-server:latest
     build: ./services/topics-server
     container_name: "sandcastle_topics-server"
+    hostname: ${TOPICS_SERVER_HOST:?err}
     env_file:
       - .env
     volumes:
       - ./services/topics-server:/workspace
       - topics-server_node_modules:/workspace/node_modules
-    networks:
-      - adnetwork
-
-  ad-server:
-    image: gcr.io/privacy-sandbox-demos/ad-server:latest
-    build: ./services/ad-server
-    container_name: "sandcastle_ad_server"
-    env_file:
-      - .env
-    volumes:
-      - ./services/ad-server:/workspace
-      - ad_server_node_modules:/workspace/node_modules
     networks:
       - adnetwork
 
@@ -209,10 +222,10 @@ services:
       - dsp
       - dsp-a
       - dsp-b
+      - ad-server
       - collector
       - topics
       - topics-server
-      - ad-server
 
 networks:
   adnetwork:

--- a/services/ssp-b/src/index.js
+++ b/services/ssp-b/src/index.js
@@ -83,7 +83,7 @@ app.get('/', async (req, res) => {
   const title = SSP_B_DETAIL;
   res.render('index.html.ejs', {
     title,
-    DSP_HOST,
+    DSP_B_HOST,
     SSP_B_HOST,
     EXTERNAL_PORT,
     SHOP_HOST,

--- a/services/ssp-b/src/views/index.html.ejs
+++ b/services/ssp-b/src/views/index.html.ejs
@@ -27,24 +27,24 @@
     <p>Ads will embed inside &lt;fencedframe&gt; like below.</p>
     <ins class="ads">
       <script class="ssp_tag"
-              src="<%= new URL(`https://${SSP_HOST}:${EXTERNAL_PORT}/ad-tag.js`) %>"></script>
+              src="<%= new URL(`https://${SSP_B_HOST}:${EXTERNAL_PORT}/ad-tag.js`) %>"></script>
     </ins>
 
     <h2>inside iframe</h2>
     <ul>
       <li>
         <a target="_blank"
-           href="<%= new URL(`https://${SSP_HOST}:${EXTERNAL_PORT}/ad-tag.html`) %>">
+           href="<%= new URL(`https://${SSP_B_HOST}:${EXTERNAL_PORT}/ad-tag.html`) %>">
           <%= new
-              URL(`https://${SSP_HOST}:${EXTERNAL_PORT}/ad-tag.html`)
+              URL(`https://${SSP_B_HOST}:${EXTERNAL_PORT}/ad-tag.html`)
               %>
         </a>
       </li>
       <li>
         <a target="_blank"
-           href="<%= new URL(`https://${DSP_HOST}:${EXTERNAL_PORT}/ads?advertiser=${SHOP_HOST}&id=1f45e`) %>">
+           href="<%= new URL(`https://${DSP_B_HOST}:${EXTERNAL_PORT}/ads?advertiser=${SHOP_HOST}&id=1f45e`) %>">
           <%= new
-              URL(`https://${DSP_HOST}:${EXTERNAL_PORT}/ads?advertiser=${SHOP_HOST}&id=1f45e`)
+              URL(`https://${DSP_B_HOST}:${EXTERNAL_PORT}/ads?advertiser=${SHOP_HOST}&id=1f45e`)
               %>
         </a>
       </li>
@@ -53,7 +53,7 @@
     <p>3rd party script provided by ssp should embed as below</p>
     <pre>
 &lt;ins class="ads"&gt;
-  &lt;script class="ssp_tag" src="<%= new URL(`https://${SSP_HOST}:${EXTERNAL_PORT}/ad-tag.js`) %>"&gt;&lt;/script&gt;
+  &lt;script class="ssp_tag" src="<%= new URL(`https://${SSP_B_HOST}:${EXTERNAL_PORT}/ad-tag.js`) %>"&gt;&lt;/script&gt;
 &lt;/ins&gt;</pre>
   </section>
 </body>


### PR DESCRIPTION
# Description

- This change makes multi-seller-auction demo in order to run both on docker & cloud run : FQDN (privacy-sandbox-demos-xxx.dev) can be used to communicate between services on the docker network.  Please remove references to DSP_A_HOST_INTERNAL, DSP_B_HOST_INTERNAL, SSP_A_HOST_INTERNAL, SSP_B_HOST_INTERNAL and use DSP_A_HOST, DSP_B_HOST etc. instead.
- fixes missing references to SSP-B / DSP-B in SSP-B  index page

## Related Issue

- Fixes #xxx

## Affected services

- [ ] Home
- [ ] News
- [ ] Shop
- [ ] Travel
- [ ] DSP
- [ ] SSP
- [ ] SSP-A
- [x] SSP-B
- [ ] ALL

Other:
- docker network settings
