### PR TITLE
Use case private aggregation gcp

### DIFF
--- a/cleanup.sh
+++ b/cleanup.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+sudo docker-compose stop
+
+sudo docker-compose rm
+
+sudo docker volume prune
+
+sudo docker system prune -a

--- a/cleanup.sh
+++ b/cleanup.sh
@@ -1,9 +1,0 @@
-#!/bin/bash
-
-sudo docker-compose stop
-
-sudo docker-compose rm
-
-sudo docker volume prune
-
-sudo docker system prune -a

--- a/services/dsp/src/index.ts
+++ b/services/dsp/src/index.ts
@@ -153,8 +153,12 @@ app.post("/.well-known/private-aggregation/report-shared-storage", (req, res) =>
 
 })
 
-app.get("/private-aggregation", (req, res) => {
-  res.render('private-aggregation');
+app.get("/private-aggregation-aws", (req, res) => {
+  res.render('private-aggregation-aws');
+})
+
+app.get("/private-aggregation-gcp", (req, res) => {
+  res.render('private-aggregation-gcp');
 })
 
 app.post("/.well-known/private-aggregation/debug/report-shared-storage", (req, res) => {

--- a/services/dsp/src/public/js/dsp.js
+++ b/services/dsp/src/public/js/dsp.js
@@ -1,7 +1,10 @@
 let dsp = document.currentScript.getAttribute('dsp');
 window.addEventListener("load", (event) => {
     let iframe = document.createElement('iframe');
+    let iframe2 = document.createElement('iframe');
     // let dsp = document.currentScript.getAttribute('dsp');
-    iframe.src = `https://${dsp}/private-aggregation`;
+    iframe.src = `https://${dsp}/private-aggregation-aws`;
+    iframe2.src = `https://${dsp}/private-aggregation-gcp`;
     document.body.appendChild(iframe);
+    document.body.appendChild(iframe2);
   });

--- a/services/dsp/src/public/js/private-aggregation-aws-worklet.js
+++ b/services/dsp/src/public/js/private-aggregation-aws-worklet.js
@@ -1,6 +1,6 @@
 class TestPrivateAggregation {
     async run(data){
-        console.log("Enabling Private Aggregation Debug Mode");
+        console.log("Enabling AWS Private Aggregation Debug Mode");
         privateAggregation.enableDebugMode({debugKey: 1234n});
         let campaignId = await sharedStorage.get('campaignId');
         if(!campaignId) {

--- a/services/dsp/src/public/js/private-aggregation-aws.js
+++ b/services/dsp/src/public/js/private-aggregation-aws.js
@@ -1,0 +1,9 @@
+async function runPrivateAggregationAws() {
+	const privateAggCloud = {'privateAggregationConfig':
+    {'aggregationCoordinatorOrigin': 'https://publickeyservice.msmt.aws.privacysandboxservices.com'}};
+
+	await window.sharedStorage.worklet.addModule('js/private-aggregation-aws-worklet.js');
+	await window.sharedStorage.run('test-private-aggregation', privateAggCloud);
+}
+
+runPrivateAggregationAws();

--- a/services/dsp/src/public/js/private-aggregation-gcp-worklet.js
+++ b/services/dsp/src/public/js/private-aggregation-gcp-worklet.js
@@ -1,0 +1,24 @@
+class TestPrivateAggregation {
+    async run(data){
+        console.log("Enabling GCP Private Aggregation Debug Mode");
+        privateAggregation.enableDebugMode({debugKey: 1234n});
+        let campaignId = await sharedStorage.get('campaignId');
+        if(!campaignId) {
+            console.log("No campaign id found for client. Adding campaignId 1234567890.");
+            campaignId = "1234567890";
+            sharedStorage.set("campaignId", campaignId);
+        } else {
+            console.log(`Campaign ID found: ${campaignId}`);
+        }
+        function convertToBucket(bucketId){
+            return BigInt(bucketId);
+        }
+        const bucket = convertToBucket(campaignId);
+        const value = 128;
+        privateAggregation.contributeToHistogram({bucket, value});      
+
+    }
+
+}
+
+register("test-private-aggregation", TestPrivateAggregation);

--- a/services/dsp/src/public/js/private-aggregation-gcp.js
+++ b/services/dsp/src/public/js/private-aggregation-gcp.js
@@ -1,0 +1,9 @@
+async function runPrivateAggregationAws() {
+	const privateAggCloud = {'privateAggregationConfig':
+    {'aggregationCoordinatorOrigin': 'https://publickeyservice.msmt.gcp.privacysandboxservices.com'}};
+
+	await window.sharedStorage.worklet.addModule('js/private-aggregation-gcp-worklet.js');
+	await window.sharedStorage.run('test-private-aggregation', privateAggCloud);
+}
+
+runPrivateAggregationAws();

--- a/services/dsp/src/public/js/private-aggregation.js
+++ b/services/dsp/src/public/js/private-aggregation.js
@@ -1,6 +1,0 @@
-async function runPrivateAggregation() {
-	await window.sharedStorage.worklet.addModule('js/private-aggregation-worklet.js');
-	await window.sharedStorage.run('test-private-aggregation');
-}
-
-runPrivateAggregation();

--- a/services/dsp/src/views/private-aggregation-aws.ejs
+++ b/services/dsp/src/views/private-aggregation-aws.ejs
@@ -1,0 +1,5 @@
+<html>
+    <header>
+        <script src="/js/private-aggregation-aws.js"></script>
+    </header>
+</html>

--- a/services/dsp/src/views/private-aggregation-gcp.ejs
+++ b/services/dsp/src/views/private-aggregation-gcp.ejs
@@ -1,0 +1,5 @@
+<html>
+    <header>
+        <script src="/js/private-aggregation-gcp.js"></script>
+    </header>
+</html>

--- a/services/dsp/src/views/private-aggregation.ejs
+++ b/services/dsp/src/views/private-aggregation.ejs
@@ -1,5 +1,0 @@
-<html>
-    <header>
-        <script src="/js/private-aggregation.js"></script>
-    </header>
-</html>

--- a/setup.sh
+++ b/setup.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+npm install
+
+npm run cert
+
+cd services/home
+
+npm install
+
+npm run build
+
+cd ../..
+
+sudo npm run start


### PR DESCRIPTION
**Prior to creating a pull request, please follow all the steps in the [contributing guide](CONTRIBUTING.md).**

# Description

- Updating the private aggregation demo to generate both GCP and AWS reports.
- Added the setup.sh file to skip steps 2.2, 2.3 and 2.4 when deploying privacy sandbox demos in local environment. user will just have to run `bash setup.sh` for this step.

Please describe a summary of the changes.

## Related Issue

- Fixes #xxx

## Affected services

- [ ] Home
- [ ] News
- [ ] Shop
- [ ] Travel
- [ ] DSP
- [ ] SSP
- [ ] ALL

Other:
