### PR TITLE
[cicd] fix missing build step for ad-server attestations

### DIFF
--- a/cicd/cloudbuild.yaml
+++ b/cicd/cloudbuild.yaml
@@ -481,7 +481,8 @@ steps:
   # Build the container image
   - name: "gcr.io/cloud-builders/docker"
     id: build-ad-server
-    waitFor: ["-"]
+    waitFor:
+      - copy-attestations
     args:
       [
         "build",


### PR DESCRIPTION
# Description

[cicd] fix missing build step for ad-server attestations

## Related Issue

- NA

## Affected services

- [ ] Home
- [ ] News
- [ ] Shop
- [ ] Travel
- [ ] DSP
- [ ] SSP
- [ ] ALL

Other:
- CI/CD