### PR TITLE
[dsp] update enrollment & attestation files for dev deployment

### DIFF
--- a/cicd/attestations/privacy-sandbox-attestations.json.dsp-a.dev
+++ b/cicd/attestations/privacy-sandbox-attestations.json.dsp-a.dev
@@ -2,6 +2,43 @@
   "privacy_sandbox_api_attestations": [
     {
       "attestation_parser_version": "2",
+      "attestation_version": "2",
+      "privacy_policy": [
+        "https://policies.google.com/privacy"
+      ],
+      "ownership_token": "8aL4nSb7QNHWt9bwbgfehM7fvfV4aYWSA4FAzC5aj8dsEudaH2c9Qz6ePmDgK3x2",
+      "issued_seconds_since_epoch": 1711488878,
+      "enrollment_id": "FFH4Y",
+      "enrollment_site": "https://privacy-sandcastle-dev-dsp-a1.web.app/",
+      "platform_attestations": [
+        {
+          "platform": "chrome",
+          "attestations": {
+            "attribution_reporting_api": {
+              "ServiceNotUsedForIdentifyingUserAcrossSites": true
+            },
+            "shared_storage_api": {
+              "ServiceNotUsedForIdentifyingUserAcrossSites": true
+            },
+            "private_aggregation_api": {
+              "ServiceNotUsedForIdentifyingUserAcrossSites": true
+            },
+            "topics_api": {
+              "ServiceNotUsedForIdentifyingUserAcrossSites": true
+            },
+            "protected_audience_api": {
+              "ServiceNotUsedForIdentifyingUserAcrossSites": true
+            }
+          }
+        },
+        {
+          "platform": "android",
+          "attestations": {}
+        }
+      ]
+    },
+    {
+      "attestation_parser_version": "2",
       "attestation_version": "1",
       "privacy_policy": [
         "https://policies.google.com/privacy"

--- a/cicd/attestations/privacy-sandbox-attestations.json.dsp-b.dev
+++ b/cicd/attestations/privacy-sandbox-attestations.json.dsp-b.dev
@@ -2,6 +2,43 @@
   "privacy_sandbox_api_attestations": [
     {
       "attestation_parser_version": "2",
+      "attestation_version": "2",
+      "privacy_policy": [
+        "https://policies.google.com/privacy"
+      ],
+      "ownership_token": "SRMFy21N5S9nPiEvh6asalv9rgHv3YIal1fpVh4t4747hPh4WNsNqxya6b0UTWs3",
+      "issued_seconds_since_epoch": 1711488897,
+      "enrollment_id": "66DAC",
+      "enrollment_site": "https://privacy-sandcastle-dev-dsp-b1.web.app/",
+      "platform_attestations": [
+        {
+          "platform": "chrome",
+          "attestations": {
+            "attribution_reporting_api": {
+              "ServiceNotUsedForIdentifyingUserAcrossSites": true
+            },
+            "shared_storage_api": {
+              "ServiceNotUsedForIdentifyingUserAcrossSites": true
+            },
+            "private_aggregation_api": {
+              "ServiceNotUsedForIdentifyingUserAcrossSites": true
+            },
+            "topics_api": {
+              "ServiceNotUsedForIdentifyingUserAcrossSites": true
+            },
+            "protected_audience_api": {
+              "ServiceNotUsedForIdentifyingUserAcrossSites": true
+            }
+          }
+        },
+        {
+          "platform": "android",
+          "attestations": {}
+        }
+      ]
+    },
+    {
+      "attestation_parser_version": "2",
       "attestation_version": "1",
       "privacy_policy": [
         "https://policies.google.com/privacy"


### PR DESCRIPTION
# Description

[dsp] update enrollment & attestation files for dev deployment

On dev environment Gogole Cloud deployment uses the following domain names :
- privacy-sandcastle-dev-dsp-a1.web.app
- privacy-sandcastle-dev-dsp-b1.web.app

## Related Issue

- Fixes Attestation errors for those 2 domains

## Affected services

- [ ] Home
- [ ] News
- [ ] Shop
- [ ] Travel
- [x] DSP
- [ ] SSP
- [ ] ALL

Other:
