### PR TITLE
Use node-cache for report-store

### DIFF
--- a/services/ad-tech/package-lock.json
+++ b/services/ad-tech/package-lock.json
@@ -13,6 +13,7 @@
         "cors": "^2.8.5",
         "ejs": "^3.1.9",
         "express": "^4.18.2",
+        "node-cache": "^5.1.2",
         "structured-field-values": "^2.0.1"
       },
       "devDependencies": {
@@ -378,6 +379,15 @@
       },
       "funding": {
         "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/clone": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
+      "integrity": "sha512-3Pe/CF1Nn94hyhIYpjtiLhdCoEoz0DqQ+988E9gmeEdQZlojxnOb74wctFyuwWQHzqyf9X7C7MG8juUpqBJT8w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8"
       }
     },
     "node_modules/color-convert": {
@@ -939,6 +949,18 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/node-cache": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/node-cache/-/node-cache-5.1.2.tgz",
+      "integrity": "sha512-t1QzWwnk4sjLWaQAS8CHgOJ+RAfmHpxFWmc36IWTiWHQfs0w5JDMBS1b1ZxQteo0vVVuWJvIUKHDkkeK7vIGCg==",
+      "license": "MIT",
+      "dependencies": {
+        "clone": "2.x"
+      },
+      "engines": {
+        "node": ">= 8.0.0"
       }
     },
     "node_modules/nofilter": {

--- a/services/ad-tech/package.json
+++ b/services/ad-tech/package.json
@@ -8,7 +8,7 @@
     "start": "npm run build && node ./build/main.js",
     "build": "tsc && cp -r src/views build/",
     "ncu": "npx npm-check-updates -u",
-    "fmt": "prettier --write ."
+    "fmt": "pre-commit run --all-files"
   },
   "dependencies": {
     "cbor": "^9.0.2",

--- a/services/ad-tech/package.json
+++ b/services/ad-tech/package.json
@@ -7,7 +7,8 @@
   "scripts": {
     "start": "npm run build && node ./build/main.js",
     "build": "tsc && cp -r src/views build/",
-    "ncu": "npx npm-check-updates -u"
+    "ncu": "npx npm-check-updates -u",
+    "fmt": "prettier --write ."
   },
   "dependencies": {
     "cbor": "^9.0.2",

--- a/services/ad-tech/package.json
+++ b/services/ad-tech/package.json
@@ -14,6 +14,7 @@
     "cors": "^2.8.5",
     "ejs": "^3.1.9",
     "express": "^4.18.2",
+    "node-cache": "^5.1.2",
     "structured-field-values": "^2.0.1"
   },
   "devDependencies": {

--- a/services/ad-tech/src/controllers/report-store.ts
+++ b/services/ad-tech/src/controllers/report-store.ts
@@ -46,15 +46,12 @@ export const ReportStore = (() => {
 
   /** Add a new report to the in-memory storage. */
   const addReport = (report: Report) => {
-    Reports.set(
-      `${report.category}||${report.timestamp}`,
-      report,
-    );
+    Reports.set(`${report.category}||${report.timestamp}`, report);
   };
 
   /** Returns all reports from in-memory storage. */
   const getAllReports = (): Report[] => {
-    return Reports.keys().map(key => Reports.get(key) as Report);
+    return Reports.keys().map((key) => Reports.get(key) as Report);
   };
 
   return {

--- a/services/ad-tech/src/controllers/report-store.ts
+++ b/services/ad-tech/src/controllers/report-store.ts
@@ -46,6 +46,7 @@ export const ReportStore = (() => {
 
   /** Add a new report to the in-memory storage. */
   const addReport = (report: Report) => {
+    // TODO: Consider partitioning by use-case.
     Reports.set(`${report.category}||${report.timestamp}`, report);
   };
 

--- a/services/ad-tech/src/controllers/report-store.ts
+++ b/services/ad-tech/src/controllers/report-store.ts
@@ -14,6 +14,8 @@
  limitations under the License.
  */
 
+import NodeCache from 'node-cache';
+
 /** Basic categories of reports. */
 export enum ReportCategory {
   EVENT_LEVEL_LOG,
@@ -34,25 +36,25 @@ export interface Report {
   data: any;
 }
 
+/** TTL for in-memory reports: 10 minutes */
+export const REPORT_TTL_SECONDS = 10 * 60;
+
+/** Simple in-memory implementation of report storage. */
 export const ReportStore = (() => {
   // In-memory storage for reports.
-  const Reports: Report[] = [];
-  // Clear in-memory storage every 10 min
-  setInterval(
-    () => {
-      Reports.length = 0;
-    },
-    1000 * 60 * 10,
-  );
+  const Reports = new NodeCache({stdTTL: REPORT_TTL_SECONDS});
 
   /** Add a new report to the in-memory storage. */
   const addReport = (report: Report) => {
-    Reports.push(report);
+    Reports.set(
+      `${report.category}||${report.timestamp}`,
+      report,
+    );
   };
 
   /** Returns all reports from in-memory storage. */
   const getAllReports = (): Report[] => {
-    return [...Reports];
+    return Reports.keys().map(key => Reports.get(key) as Report);
   };
 
   return {


### PR DESCRIPTION
**Prior to creating a pull request, please follow all the steps in the [contributing guide](CONTRIBUTING.md).**

# Description

Upgrade the in-memory `report-store` module to use `node-cache` instead of an array. With this change, we can set a TTL for items in the store such that they'll expire progressively. This is as opposed to the current implementation where the entire store is cleaned periodically regardless of when the items were created.

## Affected services

- [ ] Home
- [ ] News
- [ ] Shop
- [ ] Travel
- [ ] DSP
- [ ] SSP
- [ ] ALL
- [x] Unified Ad-tech

Other:
