### PR TITLE
Make Protected Audience bidding and decision logic scripts more readable

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "docker": "docker-compose build && docker-compose up",
     "deploy": "./scripts/cloudrun_deploy.sh && ./scripts/firebase_deploy.sh",
     "clean": "docker-compose rm -f && docker volume prune -f && docker image prune -f && docker rmi -f $(docker images -q)",
-    "fmt": "prettier --write ."
+    "fmt": "pre-commit run --all-files"
   },
   "devDependencies": {
     "firebase-tools": "^11.23.0",

--- a/services/ad-tech/src/public/js/dsp/default/auction-bidding-logic.js
+++ b/services/ad-tech/src/public/js/dsp/default/auction-bidding-logic.js
@@ -36,7 +36,6 @@ function log(message, context) {
     'bidding logic',
     AUCTION_ID,
     message,
-    message,
     JSON.stringify({context}, ' ', ' '),
   );
 }

--- a/services/ad-tech/src/public/js/ssp/default/auction-decision-logic.js
+++ b/services/ad-tech/src/public/js/ssp/default/auction-decision-logic.js
@@ -36,7 +36,6 @@ function log(message, context) {
     'decision logic',
     AUCTION_ID,
     message,
-    message,
     JSON.stringify({context}, ' ', ' '),
   );
 }

--- a/services/ad-tech/src/public/js/ssp/default/auction-decision-logic.js
+++ b/services/ad-tech/src/public/js/ssp/default/auction-decision-logic.js
@@ -82,14 +82,12 @@ function getRejectScoreIfCreativeBlocked(scoringContext) {
       'BLOCKED' === parsedScoringSignals.label.toUpperCase()
     ) {
       // Reject bid if creative is blocked.
-      // Reject bid if creative is blocked.
       log('rejecting bid blocked by publisher', {
         parsedScoringSignals,
         trustedScoringSignals,
         renderURL,
         buyer: browserSignals.interestGroupOwner,
         dataVersion: browserSignals.dataVersion,
-        scoringContext,
         scoringContext,
       });
       return {

--- a/services/ad-tech/src/routes/dsp/buyer-contextual-bidder-router.ts
+++ b/services/ad-tech/src/routes/dsp/buyer-contextual-bidder-router.ts
@@ -82,6 +82,8 @@ BuyerContextualBidderRouter.get('/', async (req: Request, res: Response) => {
     renderURL,
     buyerSignals: {
       auctionId,
+      buyerHost: HOSTNAME,
+      buyerOrigin: CURRENT_ORIGIN,
       contextualBid: bid,
       contextualRenderURL: renderURL,
       contextualAdvertiser: ADVERTISER_CONTEXTUAL,


### PR DESCRIPTION
# Description

Clean buyer's `auction-bidding-logic` and seller's `auction-decision-logic` for Protected Audience to make the scripts more readable.

Changelog:

* Update the top-level `package.json` file to run all pre-commit hooks with the `fmt` command.
* Move all logic related to console logging from `generateBid()` and `reportWin()` in `auction-bidding-logic` and `scoreAd()` and `reportResult()` in `auction-decision-logic` to helper function: `logContextForDemo()`.
* Move the logic to check for campaign status in `trustedBiddingSignals` during `generateBid()` to helper function: `isCurrentCampaignActive()`.
* Move the logic to reject bids if creative is blocked by the publisher during `scoreAd()` to helper function: `getRejectScoreIfCreativeBlocked()`.
* Include buyer hostname and origin in `buyerSignals` returned along with the contextual bid response so that this is available in context for logging during `reportWin()`.

## Affected services

- [ ] Home
- [ ] News
- [ ] Shop
- [ ] Travel
- [ ] DSP
- [ ] SSP
- [ ] ALL
- [x] Ad-tech
