### PR TITLE
Refine the initial deals use-case implementation to more closely resemble real-world usage.

### DIFF
--- a/services/ad-tech/src/controllers/key-value-store.ts
+++ b/services/ad-tech/src/controllers/key-value-store.ts
@@ -27,7 +27,7 @@ export class KeyValueStore {
     defaultValues: string[][] = [],
     resetIntervalInMins: number = 30,
   ) {
-    console.log('Initializing in-memory key value store.');
+    console.log('Initializing in-memory key value store.', {defaultValues});
     this.defaultData = defaultValues;
     this.rewriteDefaults();
     setInterval(this.rewriteDefaults, 1000 * 60 * resetIntervalInMins);

--- a/services/ad-tech/src/lib/constants.ts
+++ b/services/ad-tech/src/lib/constants.ts
@@ -88,23 +88,19 @@ export const CONTEXTUAL_BID_MIN = 0.5;
 // ****************************************************************************
 // NOTE: These bidding signals are stored in the BYOS Key-Value Server, where
 // values are stored as strings.
-export const BIDDING_SIGNAL_KEY_IS_ACTIVE = 'isActive';
-export const BIDDING_SIGNAL_KEY_BID_MIN = 'minBid';
-export const BIDDING_SIGNAL_KEY_BID_MAX = 'maxBid';
-export const BIDDING_SIGNAL_KEY_BID_MULTIPLIER = 'multiplier';
 /** The deafult bidding signals for the BYOS Key-Value Serice. */
 export const BIDDING_SIGNALS_DEFAULT = [
   // Whether the campaign is active.
-  [BIDDING_SIGNAL_KEY_IS_ACTIVE, 'true'],
+  ['isActive', 'true'],
   // Min bid CPM for Protected Audience auctions.
-  [BIDDING_SIGNAL_KEY_BID_MIN, '3.5'],
+  ['minBid', '3.5'],
   // Max bid CPM for Protected Audience auctions.
-  [BIDDING_SIGNAL_KEY_BID_MAX, '4.5'],
+  ['maxBid', '4.5'],
   // Default bid multiplier for Protected Audience auctions.
-  [BIDDING_SIGNAL_KEY_BID_MULTIPLIER, '1.1'],
+  ['multiplier', '1.1'],
 ];
+/** Deal specific bid multipliers for Protected Audience auctions. */
 export const BIDDING_SIGNALS_DEALS = [
-  // Deal specific bid multipliers for Protected Audience auctions.
   // Template for keys: `multiplier-${dealId}`
   ['multiplier-deal-1', '0.5'], // Deal ID: deal-1
   ['multiplier-deal-2', '0.4'], // Deal ID: deal-2

--- a/services/ad-tech/src/lib/constants.ts
+++ b/services/ad-tech/src/lib/constants.ts
@@ -69,17 +69,47 @@ export const CURRENT_ORIGIN = new URL(
 ).toString();
 
 // ****************************************************************************
-// CONTEXTUAL AUCTION METADATA
+// BIDDING SIGNALS - CONTEXTUAL AUCTIONS
 // ****************************************************************************
+// NOTE: These bidding signals are only used on the server-side to respond to a
+// contextual bid request from the browser or server-to-server.
 /**
  * Name of the contextual advertiser.
  * This is used in the buyer's bid response to contextual bid requests.
  */
 export const ADVERTISER_CONTEXTUAL = 'ContextNext';
 /** Max bid CPM for contextual auctions. */
-export const MAX_CONTEXTUAL_BID = 1.5;
+export const CONTEXTUAL_BID_MAX = 1.5;
 /** Min bid CPM for contextual auctions. */
-export const MIN_CONTEXTUAL_BID = 0.5;
+export const CONTEXTUAL_BID_MIN = 0.5;
+
+// ****************************************************************************
+// BIDDING SIGNALS - PROTECTED AUDIENCE AUCTIONS
+// ****************************************************************************
+// NOTE: These bidding signals are stored in the BYOS Key-Value Server, where
+// values are stored as strings.
+export const BIDDING_SIGNAL_KEY_IS_ACTIVE = 'isActive';
+export const BIDDING_SIGNAL_KEY_BID_MIN = 'minBid';
+export const BIDDING_SIGNAL_KEY_BID_MAX = 'maxBid';
+export const BIDDING_SIGNAL_KEY_BID_MULTIPLIER = 'multiplier';
+/** The deafult bidding signals for the BYOS Key-Value Serice. */
+export const BIDDING_SIGNALS_DEFAULT = [
+  // Whether the campaign is active.
+  [BIDDING_SIGNAL_KEY_IS_ACTIVE, 'true'],
+  // Min bid CPM for Protected Audience auctions.
+  [BIDDING_SIGNAL_KEY_BID_MIN, '3.5'],
+  // Max bid CPM for Protected Audience auctions.
+  [BIDDING_SIGNAL_KEY_BID_MAX, '4.5'],
+  // Default bid multiplier for Protected Audience auctions.
+  [BIDDING_SIGNAL_KEY_BID_MULTIPLIER, '1.1'],
+];
+export const BIDDING_SIGNALS_DEALS = [
+  // Deal specific bid multipliers for Protected Audience auctions.
+  // Template for keys: `multiplier-${dealId}`
+  ['multiplier-deal-1', '0.5'], // Deal ID: deal-1
+  ['multiplier-deal-2', '0.4'], // Deal ID: deal-2
+  ['multiplier-deal-3', '0.45'], // Deal ID: deal-3
+];
 
 // ****************************************************************************
 // ADVERTISER METADATA

--- a/services/ad-tech/src/lib/interest-group-helper.ts
+++ b/services/ad-tech/src/lib/interest-group-helper.ts
@@ -33,17 +33,26 @@ export enum AdType {
 /** Interface for an interest group ad object. */
 export interface InterestGroupAd {
   // REQUIRED FIELDS
+  /** Main creative URL. */
   renderURL: string;
+  /** Custom ad metadata stored by ad-tech. */
   metadata: {
+    /** Hostname of the advertiser. */
     advertiser: string;
+    /** DSIPLAY or VIDEO */
     adType: AdType;
-    adSizes?: {width: string; height: string}[];
+    /** List of compatible ad sizes. */
+    adSizes?: InterestGroupAdSize[];
   };
   // OPTIONAL FIELDS
+  /** Associated ad size group label. */
   sizeGroup?: string;
   // [Optional] Reporting IDs
+  /** Selectable reporting ID accessible to both buyer and seller. */
   selectableBuyerAndSellerReportingIds?: string[];
+  /** Non-selectable reporting ID accessible to buyer only. */
   buyerReportingId?: string;
+  /** Non-selectable reporting ID accessible to both buyer and seller. */
   buyerAndSellerReportingId?: string;
 }
 

--- a/services/ad-tech/src/lib/interest-group-helper.ts
+++ b/services/ad-tech/src/lib/interest-group-helper.ts
@@ -77,7 +77,7 @@ export interface InterestGroup {
   sizeGroups?: {[key: string]: string[]};
 }
 
-/** Generalized interface of the interest targeting context. */
+/** Generalized interface of the interest group targeting context. */
 export interface TargetingContext {
   // REQUIRED FIELDS
   /** Hostname of the advertiser. */

--- a/services/ad-tech/src/lib/interest-group-helper.ts
+++ b/services/ad-tech/src/lib/interest-group-helper.ts
@@ -12,19 +12,25 @@
  */
 
 import {
+  CURRENT_ORIGIN,
+  BIDDING_SIGNALS_DEFAULT,
   EXTERNAL_PORT,
   HOSTNAME,
   MACRO_DISPLAY_RENDER_URL_AD_SIZE,
   MACRO_VIDEO_RENDER_URL_SSP_VAST,
+  BIDDING_SIGNALS_DEALS,
 } from './constants.js';
 
+// ****************************************************************************
+// ENUMS AND INTERFACES
+// ****************************************************************************
 /** Supported ad types. */
 export enum AdType {
   DISPLAY = 'DISPLAY',
   VIDEO = 'VIDEO',
 }
 
-/** Generalized interface for an interest group ad object. */
+/** Interface for an interest group ad object. */
 export interface InterestGroupAd {
   // REQUIRED FIELDS
   renderURL: string;
@@ -41,32 +47,87 @@ export interface InterestGroupAd {
   buyerAndSellerReportingId?: string;
 }
 
+/** Generalized interface of an ad size. */
+export interface InterestGroupAdSize {
+  width: string;
+  height: string;
+}
+
+/** Top-level interface of an interest group. */
+export interface InterestGroup {
+  /** Name of the interest group: ${advertiser}-${usecase} */
+  name: string;
+  /** Origin for the ad buyer. */
+  owner: string;
+  /** URL to script defining generateBid() and reportWin(). */
+  biddingLogicURL?: string;
+  /** Endpoint for real-time bidding signals. */
+  trustedBiddingSignalsURL?: string;
+  /** Real-time bidding signals to query for. */
+  trustedBiddingSignalsKeys?: string[];
+  /** Endpoint to periodically update the interest group. */
+  updateURL?: string;
+  /** User-specific bidding signals to consider while bidding. */
+  userBiddingSignals?: {[key: string]: string};
+  /** All ads to consider while bidding. */
+  ads?: InterestGroupAd[];
+  /** Map of ad sizes indexed by a label for the size. */
+  adSizes?: {[key: string]: InterestGroupAdSize};
+  /** Map of ad size labels indexed by the ad size group label. */
+  sizeGroups?: {[key: string]: string[]};
+}
+
+/** Generalized interface of the interest targeting context. */
+export interface TargetingContext {
+  // REQUIRED FIELDS
+  /** Hostname of the advertiser. */
+  advertiser: string;
+  /** Usecase for targeting, or 'default'. */
+  usecase: string;
+  /** Whether this is a fresh request or an update. */
+  isUpdateRequest: boolean;
+  // OPTIONAL FIELDS
+  /** Advertiser prouct item ID. */
+  itemId?: string;
+  /** Real-time bidding signal keys to include in the interest group. */
+  biddingSignalKeys?: string[];
+  /** All other undocumented custom query parameters. */
+  additionalContext?: {[key: string]: string[]};
+}
+
 // ****************************************************************************
 // HELPER FUNCTIONS
 // ****************************************************************************
 /** Returns video ads for a given advertiser and SSP hosts to integrate. */
-const getVideoAdForRequest = (advertiser: string): InterestGroupAd => {
+const getVideoAdForRequest = (
+  targetingContext: TargetingContext,
+): InterestGroupAd => {
+  const {advertiser} = targetingContext;
   const renderUrl = new URL(
     `https://${HOSTNAME}:${EXTERNAL_PORT}/ads/video-ads?`,
   );
   renderUrl.searchParams.append('advertiser', advertiser);
-  return {
+  const ad: InterestGroupAd = {
     renderURL: `${renderUrl.toString()}&${MACRO_VIDEO_RENDER_URL_SSP_VAST}`,
     metadata: {
       advertiser,
       adType: AdType.VIDEO,
     },
-    selectableBuyerAndSellerReportingIds: ['deal1', 'deal2', 'deal3'],
     buyerReportingId: 'buyerSpecificInfo1',
     buyerAndSellerReportingId: 'seatid-1234',
   };
+  if (targetingContext.isUpdateRequest) {
+    // Only include deal IDs in update requests.
+    ad.selectableBuyerAndSellerReportingIds = ['deal-1', 'deal-2', 'deal-3'];
+  }
+  return ad;
 };
 
 /** Returns the interest group display ad to for the given advertiser. */
 const getDisplayAdForRequest = (
-  advertiser: string,
-  itemId?: string,
+  targetingContext: TargetingContext,
 ): InterestGroupAd => {
+  const {advertiser, itemId} = targetingContext;
   const renderUrl = new URL(
     `https://${HOSTNAME}:${EXTERNAL_PORT}/ads/display-ads`,
   );
@@ -74,7 +135,7 @@ const getDisplayAdForRequest = (
   if (itemId) {
     renderUrl.searchParams.append('itemId', itemId);
   }
-  return {
+  const ad: InterestGroupAd = {
     renderURL: `${renderUrl.toString()}&${MACRO_DISPLAY_RENDER_URL_AD_SIZE}`,
     metadata: {
       advertiser,
@@ -82,24 +143,104 @@ const getDisplayAdForRequest = (
       adSizes: [{width: '300px', height: '250px'}],
     },
     sizeGroup: 'medium-rectangle',
-    selectableBuyerAndSellerReportingIds: ['deal1', 'deal2', 'deal3'],
     buyerReportingId: 'buyerSpecificInfo1',
     buyerAndSellerReportingId: 'seatid-1234',
   };
+  if (targetingContext.isUpdateRequest) {
+    // Only include deal IDs in update requests.
+    ad.selectableBuyerAndSellerReportingIds = ['deal-1', 'deal-2', 'deal-3'];
+  }
+  return ad;
+};
+
+/** Returns the interest group name to use. */
+const getInterestGroupName = (targetingContext: TargetingContext): string => {
+  const {advertiser, usecase} = targetingContext;
+  return `${advertiser}-${usecase}`;
+};
+
+/** Returns the update URL with the targeting context. */
+const constructInterestGroupUpdateUrl = (
+  targetingContext: TargetingContext,
+): string => {
+  const interestGroupName = getInterestGroupName(targetingContext);
+  const updateURL = new URL(
+    `https://${HOSTNAME}:${EXTERNAL_PORT}/dsp/interest-group-update.json`,
+  );
+  updateURL.searchParams.append('interestGroupName', interestGroupName);
+  updateURL.searchParams.append('advertiser', targetingContext.advertiser);
+  updateURL.searchParams.append('usecase', targetingContext.usecase);
+  if (targetingContext.itemId) {
+    updateURL.searchParams.append('itemId', targetingContext.itemId);
+  }
+  if (targetingContext.biddingSignalKeys?.length) {
+    updateURL.searchParams.append(
+      'biddingSignalKeys',
+      targetingContext.biddingSignalKeys.join(','),
+    );
+  }
+  if (targetingContext.additionalContext) {
+    for (const [key, value] of Object.entries(
+      targetingContext.additionalContext,
+    )) {
+      updateURL.searchParams.append(key, value.join(','));
+    }
+  }
+  return updateURL.toString();
+};
+
+/** Returns the bidding signal keys to include in the interest group. */
+const getBiddingSignalKeys = (targetingContext: TargetingContext): string[] => {
+  const biddingSignalsKeys = [...BIDDING_SIGNALS_DEFAULT.map(([key]) => key)];
+  if (targetingContext.biddingSignalKeys) {
+    biddingSignalsKeys.push(...targetingContext.biddingSignalKeys);
+  }
+  if (targetingContext.isUpdateRequest) {
+    // Only include keys related to deals for update requests.
+    biddingSignalsKeys.push(...BIDDING_SIGNALS_DEALS.map(([key]) => key));
+  }
+  return biddingSignalsKeys;
 };
 
 // ****************************************************************************
 // EXPORTED FUNCTIONS
 // ****************************************************************************
-/** Returns the interest groups ads for the given advertiser. */
-export const getAdsForRequest = (
-  advertiser: string,
-  itemId?: string,
-): InterestGroupAd[] => {
-  // Include all types of ads in the interest group and filter based on
-  // opportunity at bidding time.
-  return [
-    getDisplayAdForRequest(advertiser, itemId),
-    getVideoAdForRequest(advertiser),
-  ];
+/** Returns the interest group for the given targeting context. */
+export const getInterestGroup = (
+  targetingContext: TargetingContext,
+): InterestGroup => {
+  const {usecase} = targetingContext;
+  const userBiddingSignals: {[key: string]: string} = {
+    'user-signal-key-1': 'user-signal-value-1',
+  };
+  if (targetingContext.additionalContext) {
+    for (const [key, values] of Object.entries(
+      targetingContext.additionalContext,
+    )) {
+      userBiddingSignals[key] = JSON.stringify(values);
+    }
+  }
+  return {
+    name: getInterestGroupName(targetingContext),
+    owner: CURRENT_ORIGIN,
+    biddingLogicURL: new URL(
+      `https://${HOSTNAME}:${EXTERNAL_PORT}/js/dsp/${usecase}/auction-bidding-logic.js`,
+    ).toString(),
+    trustedBiddingSignalsURL: new URL(
+      `https://${HOSTNAME}:${EXTERNAL_PORT}/dsp/realtime-signals/bidding-signal.json`,
+    ).toString(),
+    trustedBiddingSignalsKeys: getBiddingSignalKeys(targetingContext),
+    updateURL: constructInterestGroupUpdateUrl(targetingContext),
+    userBiddingSignals,
+    ads: [
+      getDisplayAdForRequest(targetingContext),
+      getVideoAdForRequest(targetingContext),
+    ],
+    adSizes: {
+      'medium-rectangle-default': {'width': '300px', 'height': '250px'},
+    },
+    sizeGroups: {
+      'medium-rectangle': ['medium-rectangle-default'],
+    },
+  };
 };

--- a/services/ad-tech/src/public/js/dsp/default/auction-bidding-logic.js
+++ b/services/ad-tech/src/public/js/dsp/default/auction-bidding-logic.js
@@ -293,7 +293,6 @@ function reportWin(
     renderURL: browserSignals.renderURL,
     bid: browserSignals.bid,
     bidCurrency: browserSignals.bidCurrency,
-    redirect: browserSignals.seller,
     buyerReportingId: browserSignals.buyerReportingId,
     buyerAndSellerReportingId: browserSignals.buyerAndSellerReportingId,
     selectedBuyerAndSellerReportingId:
@@ -302,13 +301,16 @@ function reportWin(
   for (const [key, value] of Object.entries(reportingContext)) {
     additionalQueryParams = additionalQueryParams.concat(`&${key}=${value}`);
   }
+  sendReportTo(
+    browserSignals.interestGroupOwner +
+      `/reporting?report=win&${additionalQueryParams}`,
+  );
+  additionalQueryParams = additionalQueryParams.concat(
+    `&redirect=${browserSignals.seller}`,
+  );
   registerAdBeacon({
     'impression': `${browserSignals.interestGroupOwner}/reporting?report=impression&${additionalQueryParams}`,
     'reserved.top_navigation_start': `${browserSignals.interestGroupOwner}/reporting?report=top_navigation_start&${additionalQueryParams}`,
     'reserved.top_navigation_commit': `${browserSignals.interestGroupOwner}/reporting?report=top_navigation_commit&${additionalQueryParams}`,
   });
-  sendReportTo(
-    browserSignals.interestGroupOwner +
-      `/reporting?report=win&${additionalQueryParams}`,
-  );
 }

--- a/services/ad-tech/src/public/js/dsp/default/auction-bidding-logic.js
+++ b/services/ad-tech/src/public/js/dsp/default/auction-bidding-logic.js
@@ -269,6 +269,10 @@ function reportWin(
     sellerSignals,
     browserSignals,
   });
+  // Assemble query parameters for event logs.
+  let additionalQueryParams = browserSignals.renderURL.substring(
+    browserSignals.renderURL.indexOf('?') + 1,
+  );
   const reportingContext = {
     auctionId: AUCTION_ID,
     pageURL: auctionSignals.pageURL,
@@ -277,15 +281,22 @@ function reportWin(
     renderURL: browserSignals.renderURL,
     bid: browserSignals.bid,
     bidCurrency: browserSignals.bidCurrency,
+    redirect: browserSignals.seller,
+    buyerReportingId: browserSignals.buyerReportingId,
+    buyerAndSellerReportingId: browserSignals.buyerAndSellerReportingId,
+    selectedBuyerAndSellerReportingId:
+      browserSignals.selectedBuyerAndSellerReportingId,
   };
-  // Add query parameters from renderURL to beacon URL.
-  const additionalQueryParams = browserSignals.renderURL
-    .substring(browserSignals.renderURL.indexOf('?') + 1)
-    .concat(`&redirect=${browserSignals.seller}`);
+  for (const [key, value] of Object.entries(reportingContext)) {
+    additionalQueryParams = additionalQueryParams.concat(`&${key}=${value}`);
+  }
   registerAdBeacon({
     'impression': `${browserSignals.interestGroupOwner}/reporting?report=impression&${additionalQueryParams}`,
     'reserved.top_navigation_start': `${browserSignals.interestGroupOwner}/reporting?report=top_navigation_start&${additionalQueryParams}`,
     'reserved.top_navigation_commit': `${browserSignals.interestGroupOwner}/reporting?report=top_navigation_commit&${additionalQueryParams}`,
   });
-  sendReportTo(browserSignals.interestGroupOwner + '/reporting?report=win');
+  sendReportTo(
+    browserSignals.interestGroupOwner +
+      `/reporting?report=win&${additionalQueryParams}`,
+  );
 }

--- a/services/ad-tech/src/public/js/dsp/default/auction-bidding-logic.js
+++ b/services/ad-tech/src/public/js/dsp/default/auction-bidding-logic.js
@@ -83,49 +83,6 @@ function isCurrentCampaignActive(biddingContext) {
   return true;
 }
 
-/** Logs execution context for demonstrative purposes. */
-function logContextForDemo(message, context) {
-  const {
-    interestGroup,
-    auctionSignals,
-    perBuyerSignals,
-    // UNUSED trustedBiddingSignals,
-    // UNUSED browserSignals,
-    sellerSignals,
-  } = context;
-  AUCTION_ID = auctionSignals.auctionId;
-  if (interestGroup) {
-    CURR_HOST = interestGroup.owner.substring('https://'.length);
-  } else if (perBuyerSignals && perBuyerSignals.buyerHost) {
-    CURR_HOST = perBuyerSignals.buyerHost;
-  } else if (sellerSignals && sellerSignals.buyer) {
-    CURR_HOST = sellerSignals.buyer.substring('https://'.length);
-  }
-  log(message, context);
-}
-
-/** Checks whether the current ad campaign is active. */
-function isCurrentCampaignActive(biddingContext) {
-  const {
-    // UNUSED interestGroup,
-    // UNUSED auctionSignals,
-    // UNUSED perBuyerSignals,
-    trustedBiddingSignals,
-    browserSignals,
-  } = biddingContext;
-  if ('true' !== trustedBiddingSignals['isActive']) {
-    // Don't place a bid if campaign is inactive.
-    log('not bidding since campaign is inactive', {
-      trustedBiddingSignals,
-      seller: browserSignals.seller,
-      topLevelSeller: browserSignals.topLevelSeller,
-      dataVersion: browserSignals.dataVersion,
-    });
-    return false;
-  }
-  return true;
-}
-
 /** Calculates a bid price based on real-time signals. */
 function calculateBidAmount(trustedBiddingSignals, dealId) {
   const minBid = Number(trustedBiddingSignals.minBid) || 0.5;
@@ -163,8 +120,6 @@ function selectDealId(selectedAd, auctionSignals) {
       return selectableBuyerAndSellerReportingIds.filter((id) =>
         auctionSignals.availableDeals.includes(id),
       );
-    } else {
-      return selectableBuyerAndSellerReportingIds;
     }
   })(auctionSignals.availableDeals.split(','));
   if (!eligibleDeals || !eligibleDeals.length) {

--- a/services/ad-tech/src/public/js/ssp/default/top-level-auction-decision-logic.js
+++ b/services/ad-tech/src/public/js/ssp/default/top-level-auction-decision-logic.js
@@ -40,6 +40,69 @@ function log(msg, context) {
   );
 }
 
+/** Logs execution context for demonstrative purposes. */
+function logContextForDemo(message, context) {
+  const {
+    // UNUSED adMetadata,
+    // UNUSED bid,
+    auctionConfig,
+    // UNUSED trustedScoringSignals,
+    browserSignals,
+  } = context;
+  CURR_HOST = auctionConfig.seller.substring('https://'.length);
+  const winningComponentSeller = browserSignals.componentSeller;
+  const winningComponentAuctionConfig = auctionConfig.componentAuctions.find(
+    (componentAuction) => winningComponentSeller === componentAuction.seller,
+  );
+  AUCTION_ID = winningComponentAuctionConfig.auctionSignals.auctionId;
+  log(message, context);
+  // Log reporting IDs if found.
+  const {buyerAndSellerReportingId, selectedBuyerAndSellerReportingId} =
+    context.browserSignals;
+  if (buyerAndSellerReportingId || selectedBuyerAndSellerReportingId) {
+    log('found reporting IDs', {
+      buyerAndSellerReportingId,
+      selectedBuyerAndSellerReportingId,
+    });
+  }
+}
+
+/** Returns a rejection score response if scored creative is blocked. */
+function getRejectScoreIfCreativeBlocked(scoringContext) {
+  const {
+    // UNUSED adMetadata,
+    // UNUSED bid,
+    // UNUSED auctionConfig,
+    trustedScoringSignals,
+    browserSignals,
+  } = scoringContext;
+  const {renderURL} = browserSignals;
+  if (trustedScoringSignals && trustedScoringSignals.renderURL[renderURL]) {
+    const parsedScoringSignals = JSON.parse(
+      trustedScoringSignals.renderURL[renderURL],
+    );
+    if (
+      parsedScoringSignals &&
+      'BLOCKED' === parsedScoringSignals.label.toUpperCase()
+    ) {
+      // Reject bid if creative is blocked.
+      log('rejecting bid blocked by publisher', {
+        parsedScoringSignals,
+        trustedScoringSignals,
+        renderURL,
+        buyer: browserSignals.interestGroupOwner,
+        dataVersion: browserSignals.dataVersion,
+        scoringContext,
+      });
+      return {
+        desirability: 0,
+        allowComponentAuction: true,
+        rejectReason: 'blocked-by-publisher',
+      };
+    }
+  }
+}
+
 // ********************************************************
 // Top-level decision logic functions
 // ********************************************************
@@ -50,41 +113,18 @@ function scoreAd(
   trustedScoringSignals,
   browserSignals,
 ) {
-  CURR_HOST = auctionConfig.seller.substring('https://'.length);
-  const {componentSeller} = browserSignals;
-  AUCTION_ID = auctionConfig.componentAuctions.find(
-    (componentAuction) => componentSeller === componentAuction.seller,
-  ).auctionSignals.auctionId;
-  log('scoring ad', {
+  const scoringContext = {
     adMetadata,
     bid,
     auctionConfig,
     trustedScoringSignals,
     browserSignals,
-  });
-  const {renderURL} = browserSignals;
-  if (trustedScoringSignals && trustedScoringSignals.renderURL[renderURL]) {
-    const parsedScoringSignals = JSON.parse(
-      trustedScoringSignals.renderURL[renderURL],
-    );
-    if (
-      parsedScoringSignals &&
-      'BLOCKED' === parsedScoringSignals.label.toUpperCase()
-    ) {
-      log('rejecting bid blocked by publisher', {
-        parsedScoringSignals,
-        trustedScoringSignals,
-        renderURL,
-        buyer: browserSignals.interestGroupOwner,
-        dataVersion: browserSignals.dataVersion,
-      });
-      return {
-        // Reject bid if creative is blocked.
-        desirability: 0,
-        allowComponentAuction: true,
-        rejectReason: 'blocked-by-publisher',
-      };
-    }
+  };
+  logContextForDemo('scoreAd()', scoringContext);
+  const creativeBlockedRejectScore =
+    getRejectScoreIfCreativeBlocked(scoringContext);
+  if (creativeBlockedRejectScore) {
+    return creativeBlockedRejectScore;
   }
   const {buyerAndSellerReportingId, selectedBuyerAndSellerReportingId} =
     browserSignals;
@@ -100,13 +140,29 @@ function scoreAd(
 }
 
 function reportResult(auctionConfig, browserSignals) {
-  CURR_HOST = auctionConfig.seller.substring('https://'.length);
+  logContextForDemo('reportResult()', {auctionConfig, browserSignals});
   const winningComponentSeller = browserSignals.componentSeller;
-  AUCTION_ID = auctionConfig.componentAuctions.find(
+  const winningComponentAuctionConfig = auctionConfig.componentAuctions.find(
     (componentAuction) => winningComponentSeller === componentAuction.seller,
-  ).auctionSignals.auctionId;
+  );
   log('reporting result', {auctionConfig, browserSignals});
-  sendReportTo(auctionConfig.seller + '/reporting?report=result');
+  const reportingContext = {
+    auctionId: AUCTION_ID,
+    pageURL: winningComponentAuctionConfig.auctionSignals.pageURL,
+    winningComponentSeller,
+    winningBuyer: browserSignals.interestGroupOwner,
+    renderURL: browserSignals.renderURL,
+    bid: browserSignals.bid,
+    bidCurrency: browserSignals.bidCurrency,
+    buyerAndSellerReportingId: browserSignals.buyerAndSellerReportingId,
+    selectedBuyerAndSellerReportingId:
+      browserSignals.selectedBuyerAndSellerReportingId,
+  };
+  let reportUrl = auctionConfig.seller + '/reporting?report=result';
+  for (const [key, value] of Object.entries(reportingContext)) {
+    reportUrl = `${reportUrl}&${key}=${value}`;
+  }
+  sendReportTo(reportUrl);
   return {
     success: true,
     auctionId: AUCTION_ID,

--- a/services/ad-tech/src/public/js/ssp/run-sequential-ad-auction.js
+++ b/services/ad-tech/src/public/js/ssp/run-sequential-ad-auction.js
@@ -37,12 +37,14 @@
     const iframeUrl = new URL(window.location.href);
     const publisher = iframeUrl.searchParams.get('publisher');
     if (message.origin !== publisher) {
-      return log('ignoring message from unknown origin', {message, publisher});
+      log('ignoring message from unknown origin', {message, publisher});
+      return [];
     }
     try {
       const {adUnit, otherSellers} = JSON.parse(message.data);
       if (!adUnit.adType) {
-        return log('stopping as adType not found in adUnit', {adUnit});
+        log('stopping as adType not found in adUnit', {adUnit});
+        return [];
       }
       if (!otherSellers || !otherSellers.length) {
         log('did not find other sellers', {adUnit, otherSellers});
@@ -50,7 +52,8 @@
       }
       return [adUnit, otherSellers];
     } catch (e) {
-      return log('encountered error in parsing adUnit config', {message});
+      log('encountered error in parsing adUnit config', {message});
+      return [];
     }
   };
 

--- a/services/ad-tech/src/routes/dsp/bidding-signals-router.ts
+++ b/services/ad-tech/src/routes/dsp/bidding-signals-router.ts
@@ -51,6 +51,7 @@ BiddingSignalsRouter.get(
     const signalsFromKeyValueStore = trustedBiddingSignalStore.getMultiple(
       queryKeys!,
     );
+    // Return perInterestGroupData for requested interes groups.
     const interestGroupNames = req.query
       .interestGroupNames!.toString()
       .split(',');
@@ -61,6 +62,7 @@ BiddingSignalsRouter.get(
           'signal1': 100,
           'signal2': 200,
         },
+        // Force an interest group update.
         'updateIfOlderThanMs': 1,
       };
     }

--- a/services/ad-tech/src/routes/dsp/buyer-contextual-bidder-router.ts
+++ b/services/ad-tech/src/routes/dsp/buyer-contextual-bidder-router.ts
@@ -17,8 +17,8 @@ import {
   CURRENT_ORIGIN,
   EXTERNAL_PORT,
   HOSTNAME,
-  MAX_CONTEXTUAL_BID,
-  MIN_CONTEXTUAL_BID,
+  CONTEXTUAL_BID_MAX,
+  CONTEXTUAL_BID_MIN,
 } from '../../lib/constants.js';
 import {AdType} from '../../lib/interest-group-helper.js';
 import {ContextualBidResponse} from '../../lib/contextual-auction-helper.js';
@@ -36,8 +36,8 @@ export const BuyerContextualBidderRouter = express.Router();
 // ************************************************************************
 /** Returns a random bid price with 2 decimal digits. */
 const getContextualBidPrice = (): string => {
-  const minBid = MIN_CONTEXTUAL_BID;
-  const maxBid = MAX_CONTEXTUAL_BID;
+  const minBid = CONTEXTUAL_BID_MIN;
+  const maxBid = CONTEXTUAL_BID_MAX;
   const bid = (Math.random() * (maxBid - minBid) + minBid).toFixed(2);
   return bid;
 };

--- a/services/news/src/views/components/aside.ejs
+++ b/services/news/src/views/components/aside.ejs
@@ -46,4 +46,15 @@
       <a href="/iframe-video-ad-single-seller">single-seller</a>
     </li>
   </ul>
+  <p class="pt-8 font-bold">Display ads with deals</p>
+  <ul class="list-disc pl-8">
+    <li>
+      with
+      <a href="/display-ad-with-deals-multi-seller">multi-seller</a>
+    </li>
+    <li class="pt-4">
+      with
+      <a href="/display-ad-with-deals-single-seller">single-seller</a>
+    </li>
+  </ul>
 </aside>

--- a/services/news/src/views/display-ad-with-deals-multi-seller.ejs
+++ b/services/news/src/views/display-ad-with-deals-multi-seller.ejs
@@ -1,0 +1,74 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport"
+    content="width=device-width, initial-scale=1.0" />
+  <title><%= TITLE %></title>
+  <link rel="stylesheet"
+        href="/css/global.css" />
+  <link rel="stylesheet"
+        href="/css/unified.css" />
+  <link rel="icon"
+        href="/img/spy.svg" />
+  <script src="/js/main.js"></script>
+  <script>
+    // Source some parameters from URL query for demonstrative purposes.
+    const searchParams = (new URL(location.href)).searchParams
+    // If strict=true is included in URL query, then reject bids without deals.
+    const strictRejectForDeals = 'true' === searchParams.get('strict');
+    // Optionally source deal IDs from URL query: deals=deal-1,deal-2,deal-3.
+    const availableDeals = [];
+    if (searchParams.has('deals')) {
+      availableDeals.push(...searchParams.get('deals').split(','));
+    } else {
+      availableDeals.push('deal-1', 'deal-2');
+    }
+    window.PSDemo = window.PSDemo || {};
+    // Publishers configure the ad units available on the page.
+    window.PSDemo.PAGE_ADS_CONFIG = Object.freeze({
+      // Seller acting as ad server is included implictly, and their tag
+      // is included on the page directly. This configuration field should
+      // list additional sellers to include in the ad auctions.
+      otherSellers: [
+        '<%= SSP_ORIGIN %>',
+        '<%= SSP_A_ORIGIN %>',
+        '<%= SSP_B_ORIGIN %>',
+      ],
+      // Ad units to request bids for.
+      adUnits: [{
+        code: 'displayFencedFrameAdUnit',
+        auctionId: `PUB-${crypto.randomUUID()}`,
+        divId: 'display-ad--fenced-frame',
+        adType: 'DISPLAY',
+        size: [300, 250],
+        isFencedFrame: true,
+        // Include available deals in ad slot config which will flow through
+        // to Protected Audience auctionSignals.
+        availableDeals,
+        strictRejectForDeals,
+      }],
+    });
+  </script>
+  <script async defer
+          src="<%= AD_SERVER_LIB_URL %>"
+  ></script>
+</head>
+
+<body class="container mx-auto flex flex-col gap-6 font-serif sm:w-full md:w-full lg:w-4/5 bg-slate-50 pt-8">
+  <%- include('components/header') %>
+  <main class="flex flex-col lg:flex-row justify-between gap-6">
+    <article class="flex flex-col gap-6 text-xl leading-6 w-full lg:w-4/6">
+      <p><%= TEXT_LOREM %></p>
+      <%- include('components/display-ads') %>
+      <p><%= TEXT_LOREM %></p>
+      <p><%= TEXT_LOREM %></p>
+      <p><%= TEXT_LOREM %></p>
+    </article>
+    <%- include('components/aside') %>
+  </main>
+  <%- include('components/footer', {HOME_HOST, EXTERNAL_PORT}) %>
+</body>
+  
+</html>

--- a/services/news/src/views/display-ad-with-deals-only.ejs
+++ b/services/news/src/views/display-ad-with-deals-only.ejs
@@ -1,0 +1,64 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport"
+    content="width=device-width, initial-scale=1.0" />
+  <title><%= TITLE %></title>
+  <link rel="stylesheet"
+        href="/css/global.css" />
+  <link rel="stylesheet"
+        href="/css/unified.css" />
+  <link rel="icon"
+        href="/img/spy.svg" />
+  <script src="/js/main.js"></script>
+  <script>
+    window.PSDemo = window.PSDemo || {};
+    // Publishers configure the ad units available on the page.
+    window.PSDemo.PAGE_ADS_CONFIG = Object.freeze({
+      // Seller acting as ad server is included implictly, and their tag
+      // is included on the page directly. This configuration field should
+      // list additional sellers to include in the ad auctions.
+      otherSellers: [
+        '<%= SSP_ORIGIN %>',
+        '<%= SSP_A_ORIGIN %>',
+        '<%= SSP_B_ORIGIN %>',
+      ],
+      // Ad units to request bids for.
+      adUnits: [{
+        code: 'displayFencedFrameAdUnit',
+        auctionId: `PUB-${crypto.randomUUID()}`,
+        divId: 'display-ad--fenced-frame',
+        adType: 'DISPLAY',
+        size: [300, 250],
+        isFencedFrame: true,
+        // Include available deals in ad slot config which will flow through
+        // to auctionSignals.
+        availableDeals: ['deal1', 'deal3'],
+        // Reject all bids that don't use the above deals.
+        strictRejectForDeals: true,
+      }],
+    });
+  </script>
+  <script async defer
+          src="<%= AD_SERVER_LIB_URL %>"
+  ></script>
+</head>
+
+<body class="container mx-auto flex flex-col gap-6 font-serif sm:w-full md:w-full lg:w-4/5 bg-slate-50 pt-8">
+  <%- include('components/header') %>
+  <main class="flex flex-col lg:flex-row justify-between gap-6">
+    <article class="flex flex-col gap-6 text-xl leading-6 w-full lg:w-4/6">
+      <p><%= TEXT_LOREM %></p>
+      <%- include('components/display-ads') %>
+      <p><%= TEXT_LOREM %></p>
+      <p><%= TEXT_LOREM %></p>
+      <p><%= TEXT_LOREM %></p>
+    </article>
+    <%- include('components/aside') %>
+  </main>
+  <%- include('components/footer', {HOME_HOST, EXTERNAL_PORT}) %>
+</body>
+  
+</html>

--- a/services/news/src/views/display-ad-with-deals-single-seller.ejs
+++ b/services/news/src/views/display-ad-with-deals-single-seller.ejs
@@ -14,17 +14,24 @@
         href="/img/spy.svg" />
   <script src="/js/main.js"></script>
   <script>
+    // Source some parameters from URL query for demonstrative purposes.
+    const searchParams = (new URL(location.href)).searchParams
+    // If strict=true is included in URL query, then reject bids without deals.
+    const strictRejectForDeals = 'true' === searchParams.get('strict');
+    // Optionally source deal IDs from URL query: deals=deal-1,deal-2,deal-3.
+    const availableDeals = [];
+    if (searchParams.has('deals')) {
+      availableDeals.push(...searchParams.get('deals').split(','));
+    } else {
+      availableDeals.push('deal-1', 'deal-2');
+    }
     window.PSDemo = window.PSDemo || {};
     // Publishers configure the ad units available on the page.
     window.PSDemo.PAGE_ADS_CONFIG = Object.freeze({
       // Seller acting as ad server is included implictly, and their tag
       // is included on the page directly. This configuration field should
       // list additional sellers to include in the ad auctions.
-      otherSellers: [
-        '<%= SSP_ORIGIN %>',
-        '<%= SSP_A_ORIGIN %>',
-        '<%= SSP_B_ORIGIN %>',
-      ],
+      otherSellers: [],
       // Ad units to request bids for.
       adUnits: [{
         code: 'displayFencedFrameAdUnit',
@@ -34,10 +41,9 @@
         size: [300, 250],
         isFencedFrame: true,
         // Include available deals in ad slot config which will flow through
-        // to auctionSignals.
-        availableDeals: ['deal1', 'deal3'],
-        // Reject all bids that don't use the above deals.
-        strictRejectForDeals: true,
+        // to Protected Audience auctionSignals.
+        availableDeals,
+        strictRejectForDeals,
       }],
     });
   </script>


### PR DESCRIPTION
# Description

Refine the initial deals use-case implementation to more closely resemble real-world usage.

## Changelog - `ad-tech` Server Side

### `ad-tech`: `lib/interest-group-helper`

  * Move the remaining interest group assembly logic to `interest-group-helper`. _(Currently, only assembling of interest group ads is included in this module.)_
  * Define generalized interfaces for `InterestGroup` and `InterestGroupAdSize` to mirror expectations of the Protected Audience API.
  * Define a new interface, `TargetingContext` that allows us to pass around arbitrary context across various modules on the `ad-tech` server while ensuring type-safety. This context includes: 
    * `advertiser`: Hostname of the advertiser
    * `usecase`: Used as switch for demonstrative purposes
    * `itemId`: Advertiser product item ID
    * `isUpdateRequest`: Is the request for an interest group object with an intent to join or update
    * `biddingSignalKeys`: Custom keys to include in trustedBiddingSignalKeys of the interest group
    * `additionalSignals`: Any other arbitrary signals to be included in the interest group `userBiddingSignals`
  * Modify assembly of interest group ads to only include `selectableBuyerAndSellerReportingIds` for update requests and not the initial join requests.

### `ad-tech`: `routes/dsp/bidding-singals-router`

* Move bidding signals related to Protected Audience auctions to `constants`. Accordingly, update references in `routes/dsp/bidding-signal-router`. Define deal specific bid multipliers in `constants`.
* Refine response logic to return `perInterestGroupData` for all interest group names included in  the request. Start with a simple implementation where we return the same response for all interest groups.
* Include `updateIfOlderThanMs` in the response to real-time bidding signals request with a values of 1ms to force an interest group update.

### `ad-tech`: `routes/dsp/buyer-router`

* Add a helper method to assemble the interest group targeting context from the incoming request. This targeting context can be passed on to `interest-group-helper` to assemble an appropriate interest group response for the request.
* Add a new endpoint to be able to update interest groups periodically: `/dsp/interest-group-update.json`

## Changelog - `ad-tech` Client Side

### `ad-tech`: `public/js/dsp/default/auction-bidding-logic`

* Modify bid calculation logic to use deal specific bid multipliers in case an eligible deal is found. This applies to both display and video ads.
* Filter deals included in the interest group by deals available in `auctionConfig`. Choose a deal at random if multiple eligible deals are found.
* Refine `reportWin()` to include additional ad auction context in auction win and ad beacon events. This context includes: seller hosts, bid, auctionId, and the various reporting IDs.

### `ad-tech`: `public/js/ssp/default/auction-decision-logic`

* Refine decision logic to also reject Protected Audience bids below the winning contextual bid with rejection reason: `bid-below-auction-floor`.
* Change rejection reason for blocked creatives to: `disapproved-by-exchange`.
* Reject bids without deals in case `strictRejectForDeals` is set to true for the ad slot.
* Boost desirability score by 10 points in case an eligible deal is included with a bid. For context, here are bidding ranges:
  * Contextual auctions: $0.5 - $1.5 (bid multiplier: 1x)
  * Regular PA auctions: $3.5 - $4.5
    * If eligible deals are NOT found, use bid multiplier: 1.1x (scored as 1P auction)
    * If eligible deals ARE found, use deal-specific multipliers: ~0.5x (score boosted by 10)
* Refine `reportResult()` to include additional ad auction context in auction result and ad beacon events. This context includes: buyer host, auction ID, page URL, bid, and the various reporting IDs.

### `ad-tech`: `public/js/ssp/default/top-level-auction-decision-logic`

* Simplify decision logic to eliminate checks that the `ad-tech` would also execute as part of its own component auction, and instead only execute a first-price auction.
* Refine `reportResult()` to include additional ad auction context in auction result and ad beacon events. This context includes: buyer host, auction ID, page URL, bid, and the various reporting IDs.

### `ad-tech`: Other minor changes

* Update the `getValidatedAdUnitAndOtherSellers()` method in `public/js/ssp/run-sequential-ad-auction` to always return an array type to avoid unexpected console errors.

## Changelog - `news`

* Add 2 new test pages: `display-ad-with-deals-single-seller` and `display-ad-with-deals-multi-seller`. Both pages define a single iframe display ad slot with available deal IDs.
  * The ad slot config also requires all bids to have a valid deal associated with it. This default behavior can be modified by adding the query parameter: `strict=false` to the publisher page URL.
* Include these 2 new pages in `aside` so that they appear on the test pages index.

## Affected services

- [ ] Home
- [x] News
- [ ] Shop
- [ ] Travel
- [ ] DSP
- [ ] SSP
- [ ] ALL
- [x] Ad-tech

Other:
