### PR TITLE
Add UC-6: Incorporating publisher ad quality requirements in Protected Audience

### DIFF
--- a/services/news/src/index.ts
+++ b/services/news/src/index.ts
@@ -33,6 +33,7 @@ const {
 const app: Application = express();
 
 const TITLE = NEWS_DETAIL;
+const PUBLISHER_ADS_REQ_TITLE = NEWS_DETAIL + ' (with ad blocking)';
 const LOREM =
   'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.';
 
@@ -89,7 +90,7 @@ app.get('/uc-publisher-ads-req', async (req: Request, res: Response) => {
   const cloudEnv = req.query.env;
 
   res.render('uc-publisher-ads-req', {
-    title: TITLE,
+    title: PUBLISHER_ADS_REQ_TITLE,
     lorem: LOREM,
     EXTERNAL_PORT,
     HOME_HOST,

--- a/services/news/src/index.ts
+++ b/services/news/src/index.ts
@@ -82,3 +82,24 @@ app.get('/video-ad', async (req: Request, res: Response) => {
 app.listen(PORT, async () => {
   console.log(`Listening on port ${PORT}`);
 });
+
+app.get('/uc-publisher-ads-req', async (req: Request, res: Response) => {
+  const {auctionType} = req.query;
+  const bucket = req.query.key;
+  const cloudEnv = req.query.env;
+
+  res.render('uc-publisher-ads-req', {
+    title: TITLE,
+    lorem: LOREM,
+    EXTERNAL_PORT,
+    HOME_HOST,
+    NEWS_TOKEN,
+    DSP_HOST,
+    SSP_A_HOST,
+    SSP_B_HOST,
+    AD_SERVER_HOST,
+    SSP_TAG_URL: `https://${SSP_HOST}/js/uc-publisher-ads-req/ad-tag.js`,
+    bucket: bucket,
+    cloudEnv: cloudEnv,
+  });
+});

--- a/services/news/src/views/uc-publisher-ads-req.ejs
+++ b/services/news/src/views/uc-publisher-ads-req.ejs
@@ -6,10 +6,27 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title><%= title %></title>
   <link rel="stylesheet" href="/css/global.css" />
-  <link rel="stylesheet" href="/css/hide-button-style.css">
   <link rel="icon" href="/img/spy.svg" />
   <meta http-equiv="origin-trial" content="<%= NEWS_TOKEN %>">
   <script src="<%= `https://${DSP_HOST}:${EXTERNAL_PORT}/js/dsp.js` %>" dsp="<%= `${DSP_HOST}:${EXTERNAL_PORT}` %>" bucket="<%= `${bucket}` %>" cloudenv="<%= `${cloudEnv}` %>"></script>
+  <style>
+    .hide-button-container {
+      display: flex;
+      flex-direction: row;
+      justify-content: center;
+    }
+
+    .hide-button {
+      background: gray;
+      border-radius: 5px;
+      color: white;
+      font-size: 14px;
+      margin: 5px;
+      padding: 7px;
+      text-align: center;
+      text-decoration: none;
+    }
+  </style>
 </head>
 
 <body class="container mx-auto flex flex-col gap-6 font-serif sm:w-full md:w-full lg:w-4/5 bg-slate-50 pt-8">

--- a/services/news/src/views/uc-publisher-ads-req.ejs
+++ b/services/news/src/views/uc-publisher-ads-req.ejs
@@ -1,0 +1,74 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title><%= title %></title>
+  <link rel="stylesheet" href="/css/global.css" />
+  <link rel="stylesheet" href="/css/hide-button-style.css">
+  <link rel="icon" href="/img/spy.svg" />
+  <meta http-equiv="origin-trial" content="<%= NEWS_TOKEN %>">
+  <script src="<%= `https://${DSP_HOST}:${EXTERNAL_PORT}/js/dsp.js` %>" dsp="<%= `${DSP_HOST}:${EXTERNAL_PORT}` %>" bucket="<%= `${bucket}` %>" cloudenv="<%= `${cloudEnv}` %>"></script>
+</head>
+
+<body class="container mx-auto flex flex-col gap-6 font-serif sm:w-full md:w-full lg:w-4/5 bg-slate-50 pt-8">
+  <header class="flex flex-col items-center gap-4">
+    <h1 class="text-6xl">Daily Privacy News</h1>
+    <h2 class="text-2xl">A news demo site which allows blocking of ads</h2>
+    <hr class="w-full">
+  </header>
+  <main class="flex flex-col lg:flex-row justify-between gap-6">
+    <article class="flex flex-col gap-6 text-xl leading-6 w-full lg:w-4/6">
+      <p><%= lorem %></p>
+      <div class="hide-button-container">
+        <a href="/uc-publisher-ads-req" class="hide-button">Show all shoes</a>
+        <a href="/uc-publisher-ads-req?excludeProductTag=red_shoe" class="hide-button">Hide red shoes</a>
+        <a href="/uc-publisher-ads-req?excludeProductTag=blue_shoe" class="hide-button">Hide blue shoes</a>
+        <a href="/uc-publisher-ads-req?excludeProductTag=brown_shoe" class="hide-button">Hide brown shoes</a>
+        <a href="/uc-publisher-ads-req?excludeProductTag=sports_shoe" class="hide-button">Hide sports shoes</a>
+      </div>
+
+      <div class="w-full flex flex-col items-center">
+        <ins class="ads"></ins>
+      </div>
+      <p><%= lorem %></p>
+      <div class="w-full flex flex-col items-center">
+      </div>
+      <p><%= lorem %></p>
+      <p><%= lorem %></p>
+      <p><%= lorem %></p>
+    </article>
+
+    <aside class="flex flex-col gap-4">
+      <h3 class="font-bold text-2xl">
+        Today's stories
+      </h3>
+      <ul class="list-disc pl-4">
+        <li><a href=#>Lorem ipsum dolor sit amet</a></li>
+        <li><a href=#>consectetur adipiscing elit</a></li>
+        <li><a href=#>sed do eiusmod tempor incididunt</a></li>
+        <li><a href=#>ut labore et dolore magna aliqua</a></li>
+        <li><a href=#>Ut enim ad minim veniam</a></li>
+        <li><a href=#>quis nostrud exercitation ullamco aboris</a></li>
+        <li><a href=#>nisi ut aliquip ex ea commodo consequat</a></li>
+        <li><a href=#>Duis aute irure dolor in reprehenderit</a></li>
+        <li><a href=#>in voluptate velit esse cillum dolore</a></li>
+        <li><a href=#>eu fugiat nulla pariatur</a></li>
+      </ul>
+    </aside>
+  </main>
+  <footer>
+    <hr>
+    <p><a href=<%= `https://${HOME_HOST}:${EXTERNAL_PORT}` %>>back to top</a>
+  </footer>
+
+  <script>
+    const scriptEl = document.createElement('script')
+    scriptEl.src = '<%= SSP_TAG_URL %>'
+    scriptEl.className = 'ssp_tag'
+    document.body.appendChild(scriptEl)
+  </script>
+</body>
+
+</html>

--- a/services/ssp/src/index.js
+++ b/services/ssp/src/index.js
@@ -52,7 +52,7 @@ const {
 const app = express();
 
 const AD_RENDER_URL_START =
-  'https://privacy-sandbox-demos-dsp.dev/ads?advertiser=privacy-sandbox-demos-shop.dev&id=';
+  'https://' + DSP_HOST + '/ads?advertiser=privacy-sandbox-demos-shop.dev&id=';
 const AD_TAGS = {
   [AD_RENDER_URL_START + '1f45e']: {
     product_tags: ['brown_shoe'],

--- a/services/ssp/src/index.js
+++ b/services/ssp/src/index.js
@@ -51,6 +51,47 @@ const {
 
 const app = express();
 
+const AD_RENDER_URL_START =
+  'https://privacy-sandbox-demos-dsp.dev/ads?advertiser=privacy-sandbox-demos-shop.dev&id=';
+const AD_TAGS = {
+  [AD_RENDER_URL_START + '1f45e']: {
+    product_tags: ['brown_shoe'],
+  },
+  [AD_RENDER_URL_START + '1f45f']: {
+    product_tags: ['blue_shoe', 'sports_shoe'],
+  },
+  [AD_RENDER_URL_START + '1f460']: {
+    product_tags: ['red_shoe'],
+  },
+  [AD_RENDER_URL_START + '1f461']: {
+    product_tags: ['brown_shoe'],
+  },
+  [AD_RENDER_URL_START + '1f462']: {
+    product_tags: ['brown_shoe'],
+  },
+  [AD_RENDER_URL_START + '1f6fc']: {
+    product_tags: ['blue_shoe', 'sports_shoe'],
+  },
+  [AD_RENDER_URL_START + '1f97e']: {
+    product_tags: ['brown_shoe', 'sports_shoe'],
+  },
+  [AD_RENDER_URL_START + '1f97f']: {
+    product_tags: ['blue_shoe'],
+  },
+  [AD_RENDER_URL_START + '1fa70']: {
+    product_tags: ['brown_shoe'],
+  },
+  [AD_RENDER_URL_START + '1fa74']: {
+    product_tags: ['blue_shoe'],
+  },
+  [AD_RENDER_URL_START + '1f3bf']: {
+    product_tags: ['blue_shoe', 'sports_shoe'],
+  },
+  [AD_RENDER_URL_START + '26f8']: {
+    product_tags: ['sports_shoe'],
+  },
+};
+
 app.use((req, res, next) => {
   res.setHeader('Origin-Trial', SSP_TOKEN);
   next();
@@ -308,4 +349,25 @@ app.get('/auction-config.json', async (req, res) => {
 
 app.listen(PORT, function () {
   console.log(`Listening on port ${PORT}`);
+});
+
+app.get('/uc-publisher-ads-req/ad-tag.html', async (req, res) => {
+  res.render('uc-publisher-ads-req/ad-tag.html.ejs');
+});
+
+app.get('/trusted-scoring-uc-publisher-ads-req', async (req, res) => {
+  res.setHeader('Ad-Auction-Allowed', 'true');
+
+  const response = {
+    renderURLs: {},
+  };
+  const queryRenderUrls = req.query.renderUrls?.toString().split(',') || [];
+
+  queryRenderUrls.forEach((queryRenderUrl) => {
+    if (AD_TAGS[queryRenderUrl]) {
+      response.renderURLs[queryRenderUrl] = AD_TAGS[queryRenderUrl];
+    }
+  });
+
+  res.json(response);
 });

--- a/services/ssp/src/public/js/uc-publisher-ads-req/ad-tag.js
+++ b/services/ssp/src/public/js/uc-publisher-ads-req/ad-tag.js
@@ -1,0 +1,37 @@
+/*
+ Copyright 2022 Google LLC
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+      https://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+(async () => {
+  const $ins = document.querySelector('ins.ads');
+  const $script = document.querySelector('.ssp_tag');
+  const src = new URL($script.src);
+  src.pathname = 'uc-publisher-ads-req/ad-tag.html';
+
+  const urlParams = new URLSearchParams(window.location.search);
+  const excludeProductTagValue = urlParams.get('excludeProductTag');
+  if (excludeProductTagValue) {
+    src.searchParams.append('excludeProductTag', excludeProductTagValue);
+  }
+
+  const $iframe = document.createElement('iframe');
+  $iframe.width = 300;
+  $iframe.height = 250;
+  $iframe.src = src;
+  $iframe.setAttribute('scrolling', 'no');
+  $iframe.setAttribute('style', 'border: none');
+  $iframe.setAttribute('allow', 'attribution-reporting; run-ad-auction');
+  $ins.appendChild($iframe);
+})();

--- a/services/ssp/src/public/js/uc-publisher-ads-req/decision-logic.js
+++ b/services/ssp/src/public/js/uc-publisher-ads-req/decision-logic.js
@@ -1,0 +1,48 @@
+/*
+ Copyright 2022 Google LLC
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+      https://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+function log(label, o) {
+  console.log(label, JSON.stringify(o, ' ', ' '));
+}
+
+function scoreAd(
+  adMetadata,
+  bid,
+  auctionConfig,
+  trustedScoringSignals,
+  browserSignals,
+) {
+  if (auctionConfig.sellerSignals.excludeProductTag) {
+    const productTags =
+      trustedScoringSignals.renderURL[browserSignals.renderURL].product_tags;
+    if (productTags.includes(auctionConfig.sellerSignals.excludeProductTag)) {
+      // Exclude ad from auction - has excluded tag
+      return 0;
+    }
+  }
+
+  return bid;
+}
+
+function reportResult(auctionConfig, browserSignals) {
+  log('reportResult', {auctionConfig, browserSignals});
+  sendReportTo(auctionConfig.seller + '/reporting?report=result');
+  return {
+    success: true,
+    signalsForWinner: {signalForWinner: 1},
+    reportUrl: auctionConfig.seller + '/reporting',
+  };
+}

--- a/services/ssp/src/public/js/uc-publisher-ads-req/run-ad-auction.js
+++ b/services/ssp/src/public/js/uc-publisher-ads-req/run-ad-auction.js
@@ -1,0 +1,52 @@
+/*
+ Copyright 2022 Google LLC
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+      https://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+async function getAuctionConfig() {
+  // Grab the 'excludeProductTag' param from the url
+  var queryString = window.location.search;
+  var urlParams = new URLSearchParams(queryString);
+  var excludeProductTag = urlParams.get('excludeProductTag');
+
+  // Create the auction config
+  var jsonString =
+    `{"seller":"https://privacy-sandbox-demos-ssp.dev/",\
+    "decisionLogicUrl":"https://privacy-sandbox-demos-ssp.dev/js/uc-publisher-ads-req/decision-logic.js",\
+    "interestGroupBuyers":["https://privacy-sandbox-demos-dsp.dev/"],\
+    "auctionSignals":{"auction_signals":"auction_signals"},\
+    "sellerSignals":{"excludeProductTag":"` +
+    excludeProductTag +
+    `"},\
+    "perBuyerSignals":{"https://privacy-sandbox-demos-dsp.dev/": {"per_buyer_signals":"per_buyer_signals"}},\
+    "trustedScoringSignalsURL":"https://privacy-sandbox-demos-ssp.dev/trusted-scoring-uc-publisher-ads-req",\
+    "resolveToConfig":true}`;
+  return JSON.parse(jsonString);
+}
+
+document.addEventListener('DOMContentLoaded', async (e) => {
+  if (navigator.runAdAuction === undefined) {
+    return console.log('Protected Audience API is not supported');
+  }
+
+  const auctionConfig = await getAuctionConfig();
+  const adAuctionResult = await navigator.runAdAuction(auctionConfig);
+  const $fencedframe = document.createElement('fencedframe');
+  $fencedframe.config = adAuctionResult;
+  $fencedframe.setAttribute('mode', 'opaque-ads');
+  $fencedframe.setAttribute('scrolling', 'no');
+  $fencedframe.width = 300;
+  $fencedframe.height = 250;
+  document.body.appendChild($fencedframe);
+});

--- a/services/ssp/src/views/uc-publisher-ads-req/ad-tag.html.ejs
+++ b/services/ssp/src/views/uc-publisher-ads-req/ad-tag.html.ejs
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width,initial-scale=1" />
+<link rel="icon" href="" />
+<title></title>
+
+<style>
+  body {
+    margin: 0;
+    padding: 0;
+    box-sizing: border-box;
+    width: 100vw;
+    height: 100vh;
+
+    display: flex;
+    justify-content: center;
+    align-items: center;
+  }
+
+  fencedframe {
+    border: none;
+    width: 100vw;
+    height: 100vh;
+    background-color: aliceblue;
+  }
+</style>
+
+<script src="/js/uc-publisher-ads-req/run-ad-auction.js"></script>


### PR DESCRIPTION
# Description

In this demo, we assume a publisher would like to exclude ads with certain product types. We’ll demonstrate a publisher page calling an SSP to perform a PAAPI auction, supplying product tags to exclude which have been selected by the user (e.g. “red_shoe”). The SSP will exclude ads by calling their backend K/V server with the ad urls, and receiving ad metadata as JSON (e.g. {“product_tags”: [“red_shoe”, “shorts_shoe”]}) which will be matched to the product tag to exclude.

## Affected services

- [x] Home
- [ X] News
- [ ] Shop
- [ ] Travel
- [ ] DSP
- [ X] SSP
- [ ] ALL
