### PR TITLE
UC6: Incorporating publisher ad quality requirements in Protected (2nd PR attempt)

### DIFF
--- a/services/news/src/constants.ts
+++ b/services/news/src/constants.ts
@@ -28,7 +28,6 @@ export const {
   GARDENING_HOST,
 
   // Ad-techs
-  DSP_HOST,
   SSP_HOST,
   SSP_A_HOST,
   SSP_B_HOST,

--- a/services/news/src/constants.ts
+++ b/services/news/src/constants.ts
@@ -28,6 +28,7 @@ export const {
   GARDENING_HOST,
 
   // Ad-techs
+  DSP_HOST,
   SSP_HOST,
   SSP_A_HOST,
   SSP_B_HOST,

--- a/services/news/src/index.ts
+++ b/services/news/src/index.ts
@@ -18,7 +18,6 @@ import express, {Application, Request, Response} from 'express';
 
 import {
   AD_SERVER_HOST,
-  DSP_HOST,
   EXTERNAL_PORT,
   HOME_HOST,
   TEXT_LOREM,
@@ -66,7 +65,6 @@ app.get('/uc-publisher-ads-req', async (req: Request, res: Response) => {
     lorem: TEXT_LOREM,
     EXTERNAL_PORT,
     HOME_HOST,
-    DSP_HOST,
     SSP_A_HOST,
     SSP_B_HOST,
     AD_SERVER_HOST,

--- a/services/news/src/index.ts
+++ b/services/news/src/index.ts
@@ -18,6 +18,7 @@ import express, {Application, Request, Response} from 'express';
 
 import {
   AD_SERVER_HOST,
+  DSP_HOST,
   EXTERNAL_PORT,
   HOME_HOST,
   TEXT_LOREM,
@@ -31,6 +32,8 @@ import {
   SSP_HOST,
   SSP_ORIGIN,
 } from './constants.js';
+
+const PUBLISHER_ADS_REQ_TITLE = NEWS_DETAIL + ' (with ad blocking)';
 
 const app: Application = express();
 app.use(express.static('src/public'));
@@ -50,6 +53,26 @@ app.get('/', async (req: Request, res: Response) => {
     AD_SERVER_LIB_URL: `https://${AD_SERVER_HOST}/js/ad-server-lib.js`,
     HEADER_BIDDING_LIB_URL: `https://${NEWS_HOST}/js/header-bidding-lib.js`,
     IS_MULTI_SELLER: 'multi' === req.query.auctionType,
+  });
+});
+
+app.get('/uc-publisher-ads-req', async (req: Request, res: Response) => {
+  const {auctionType} = req.query;
+  const bucket = req.query.key;
+  const cloudEnv = req.query.env;
+
+  res.render('uc-publisher-ads-req', {
+    title: PUBLISHER_ADS_REQ_TITLE,
+    lorem: TEXT_LOREM,
+    EXTERNAL_PORT,
+    HOME_HOST,
+    DSP_HOST,
+    SSP_A_HOST,
+    SSP_B_HOST,
+    AD_SERVER_HOST,
+    SSP_TAG_URL: `https://${SSP_HOST}/js/uc-publisher-ads-req/ad-tag.js`,
+    bucket: bucket,
+    cloudEnv: cloudEnv,
   });
 });
 

--- a/services/news/src/views/uc-publisher-ads-req.ejs
+++ b/services/news/src/views/uc-publisher-ads-req.ejs
@@ -7,7 +7,6 @@
   <title><%= title %></title>
   <link rel="stylesheet" href="/css/global.css" />
   <link rel="icon" href="/img/spy.svg" />
-  <script src="<%= `https://${DSP_HOST}:${EXTERNAL_PORT}/js/dsp.js` %>" dsp="<%= `${DSP_HOST}:${EXTERNAL_PORT}` %>" bucket="<%= `${bucket}` %>" cloudenv="<%= `${cloudEnv}` %>"></script>
   <style>
     .hide-button-container {
       display: flex;

--- a/services/news/src/views/uc-publisher-ads-req.ejs
+++ b/services/news/src/views/uc-publisher-ads-req.ejs
@@ -1,0 +1,90 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title><%= title %></title>
+  <link rel="stylesheet" href="/css/global.css" />
+  <link rel="icon" href="/img/spy.svg" />
+  <script src="<%= `https://${DSP_HOST}:${EXTERNAL_PORT}/js/dsp.js` %>" dsp="<%= `${DSP_HOST}:${EXTERNAL_PORT}` %>" bucket="<%= `${bucket}` %>" cloudenv="<%= `${cloudEnv}` %>"></script>
+  <style>
+    .hide-button-container {
+      display: flex;
+      flex-direction: row;
+      justify-content: center;
+    }
+
+    .hide-button {
+      background: gray;
+      border-radius: 5px;
+      color: white;
+      font-size: 14px;
+      margin: 5px;
+      padding: 7px;
+      text-align: center;
+      text-decoration: none;
+    }
+  </style>
+</head>
+
+<body class="container mx-auto flex flex-col gap-6 font-serif sm:w-full md:w-full lg:w-4/5 bg-slate-50 pt-8">
+  <header class="flex flex-col items-center gap-4">
+    <h1 class="text-6xl">Daily Privacy News</h1>
+    <h2 class="text-2xl">A news demo site which allows blocking of ads</h2>
+    <hr class="w-full">
+  </header>
+  <main class="flex flex-col lg:flex-row justify-between gap-6">
+    <article class="flex flex-col gap-6 text-xl leading-6 w-full lg:w-4/6">
+      <p><%= lorem %></p>
+      <div class="hide-button-container">
+        <a href="/uc-publisher-ads-req" class="hide-button">Show all shoes</a>
+        <a href="/uc-publisher-ads-req?excludeProductTag=redShoe" class="hide-button">Hide red shoes</a>
+        <a href="/uc-publisher-ads-req?excludeProductTag=blueShoe" class="hide-button">Hide blue shoes</a>
+        <a href="/uc-publisher-ads-req?excludeProductTag=brownShoe" class="hide-button">Hide brown shoes</a>
+        <a href="/uc-publisher-ads-req?excludeProductTag=sportsShoe" class="hide-button">Hide sports shoes</a>
+      </div>
+
+      <div class="w-full flex flex-col items-center">
+        <ins class="ads"></ins>
+      </div>
+      <p><%= lorem %></p>
+      <div class="w-full flex flex-col items-center">
+      </div>
+      <p><%= lorem %></p>
+      <p><%= lorem %></p>
+      <p><%= lorem %></p>
+    </article>
+
+    <aside class="flex flex-col gap-4">
+      <h3 class="font-bold text-2xl">
+        Today's stories
+      </h3>
+      <ul class="list-disc pl-4">
+        <li><a href=#>Lorem ipsum dolor sit amet</a></li>
+        <li><a href=#>consectetur adipiscing elit</a></li>
+        <li><a href=#>sed do eiusmod tempor incididunt</a></li>
+        <li><a href=#>ut labore et dolore magna aliqua</a></li>
+        <li><a href=#>Ut enim ad minim veniam</a></li>
+        <li><a href=#>quis nostrud exercitation ullamco aboris</a></li>
+        <li><a href=#>nisi ut aliquip ex ea commodo consequat</a></li>
+        <li><a href=#>Duis aute irure dolor in reprehenderit</a></li>
+        <li><a href=#>in voluptate velit esse cillum dolore</a></li>
+        <li><a href=#>eu fugiat nulla pariatur</a></li>
+      </ul>
+    </aside>
+  </main>
+  <footer>
+    <hr>
+    <p><a href=<%= `https://${HOME_HOST}:${EXTERNAL_PORT}` %>>back to top</a>
+  </footer>
+
+  <script>
+    const scriptEl = document.createElement('script')
+    scriptEl.src = '<%= SSP_TAG_URL %>'
+    scriptEl.className = 'ssp_tag'
+    document.body.appendChild(scriptEl)
+  </script>
+</body>
+
+</html>

--- a/services/ssp/src/index.js
+++ b/services/ssp/src/index.js
@@ -42,6 +42,49 @@ const {
   SHOP_HOST,
 } = process.env;
 
+const AD_RENDER_URL_START =
+  'https://' + DSP_HOST + '/ads?advertiser=privacy-sandbox-demos-shop.dev&id=';
+const AD_RENDER_URL_END =
+  '&adSize1={%AD_WIDTH%}x{%AD_HEIGHT%}&adSize2=${AD_WIDTH}x${AD_HEIGHT}';
+const AD_TAGS = {
+  [AD_RENDER_URL_START + '1f45e' + AD_RENDER_URL_END]: {
+    product_tags: ['brownShoe'],
+  },
+  [AD_RENDER_URL_START + '1f45f' + AD_RENDER_URL_END]: {
+    product_tags: ['blueShoe', 'sportsShoe'],
+  },
+  [AD_RENDER_URL_START + '1f460' + AD_RENDER_URL_END]: {
+    product_tags: ['redShoe'],
+  },
+  [AD_RENDER_URL_START + '1f461' + AD_RENDER_URL_END]: {
+    product_tags: ['brownShoe'],
+  },
+  [AD_RENDER_URL_START + '1f462' + AD_RENDER_URL_END]: {
+    product_tags: ['brownShoe'],
+  },
+  [AD_RENDER_URL_START + '1f6fc' + AD_RENDER_URL_END]: {
+    product_tags: ['blueShoe', 'sportsShoe'],
+  },
+  [AD_RENDER_URL_START + '1f97e' + AD_RENDER_URL_END]: {
+    product_tags: ['brownShoe', 'sportsShoe'],
+  },
+  [AD_RENDER_URL_START + '1f97f' + AD_RENDER_URL_END]: {
+    product_tags: ['blueShoe'],
+  },
+  [AD_RENDER_URL_START + '1fa70' + AD_RENDER_URL_END]: {
+    product_tags: ['brownShoe'],
+  },
+  [AD_RENDER_URL_START + '1fa74' + AD_RENDER_URL_END]: {
+    product_tags: ['blueShoe'],
+  },
+  [AD_RENDER_URL_START + '1f3bf' + AD_RENDER_URL_END]: {
+    product_tags: ['blueShoe', 'sportsShoe'],
+  },
+  [AD_RENDER_URL_START + '26f8' + AD_RENDER_URL_END]: {
+    product_tags: ['sportsShoe'],
+  },
+};
+
 // In-memory storage for debug reports
 const Reports = [];
 // Clear in-memory storage every 10 min
@@ -484,4 +527,50 @@ const handleEventLevelReport = (req, res, report) => {
 
 app.listen(PORT, function () {
   console.log(`Listening on port ${PORT}`);
+});
+
+app.get('/uc-publisher-ads-req/ad-tag.html', async (req, res) => {
+  res.render('uc-publisher-ads-req/ad-tag.html.ejs');
+});
+
+app.get('/uc-publisher-ads-req/auction-config.json', async (req, res) => {
+  const dspOrigin = new URL(`https://${DSP_HOST}:${EXTERNAL_PORT}`).toString();
+  const sspOrigin = new URL(`https://${SSP_HOST}:${EXTERNAL_PORT}`).toString();
+  const auctionConfig = {
+    'seller': sspOrigin,
+    // x-allow-fledge: true
+    'decisionLogicURL': `${sspOrigin}js/uc-publisher-ads-req/decision-logic.js`,
+    'interestGroupBuyers': [dspOrigin],
+    'auctionSignals': {
+      'auction_signals': 'auction_signals',
+    },
+    'perBuyerSignals': {
+      [dspOrigin]: {
+        'per_buyer_signals': 'per_buyer_signals',
+      },
+    },
+    'trustedScoringSignalsURL': `${sspOrigin}/trusted-scoring-uc-publisher-ads-req`,
+    // Needed for size macro replacements.
+    'requestedSize': {'width': '300px', 'height': '250px'},
+    // If set to true, runAdAuction returns a FencedFrameConfig.
+    'resolveToConfig': true,
+  };
+  res.json(auctionConfig);
+});
+
+app.get('/trusted-scoring-uc-publisher-ads-req', async (req, res) => {
+  res.setHeader('Ad-Auction-Allowed', 'true');
+
+  const response = {
+    renderURLs: {},
+  };
+  const queryRenderUrls = req.query.renderUrls?.toString().split(',') || [];
+
+  queryRenderUrls.forEach((queryRenderUrl) => {
+    if (AD_TAGS[queryRenderUrl]) {
+      response.renderURLs[queryRenderUrl] = AD_TAGS[queryRenderUrl];
+    }
+  });
+
+  res.json(response);
 });

--- a/services/ssp/src/index.js
+++ b/services/ssp/src/index.js
@@ -48,40 +48,40 @@ const AD_RENDER_URL_END =
   '&adSize1={%AD_WIDTH%}x{%AD_HEIGHT%}&adSize2=${AD_WIDTH}x${AD_HEIGHT}';
 const AD_TAGS = {
   [AD_RENDER_URL_START + '1f45e' + AD_RENDER_URL_END]: {
-    product_tags: ['brownShoe'],
+    productTags: ['brownShoe'],
   },
   [AD_RENDER_URL_START + '1f45f' + AD_RENDER_URL_END]: {
-    product_tags: ['blueShoe', 'sportsShoe'],
+    productTags: ['blueShoe', 'sportsShoe'],
   },
   [AD_RENDER_URL_START + '1f460' + AD_RENDER_URL_END]: {
-    product_tags: ['redShoe'],
+    productTags: ['redShoe'],
   },
   [AD_RENDER_URL_START + '1f461' + AD_RENDER_URL_END]: {
-    product_tags: ['brownShoe'],
+    productTags: ['brownShoe'],
   },
   [AD_RENDER_URL_START + '1f462' + AD_RENDER_URL_END]: {
-    product_tags: ['brownShoe'],
+    productTags: ['brownShoe'],
   },
   [AD_RENDER_URL_START + '1f6fc' + AD_RENDER_URL_END]: {
-    product_tags: ['blueShoe', 'sportsShoe'],
+    productTags: ['blueShoe', 'sportsShoe'],
   },
   [AD_RENDER_URL_START + '1f97e' + AD_RENDER_URL_END]: {
-    product_tags: ['brownShoe', 'sportsShoe'],
+    productTags: ['brownShoe', 'sportsShoe'],
   },
   [AD_RENDER_URL_START + '1f97f' + AD_RENDER_URL_END]: {
-    product_tags: ['blueShoe'],
+    productTags: ['blueShoe'],
   },
   [AD_RENDER_URL_START + '1fa70' + AD_RENDER_URL_END]: {
-    product_tags: ['brownShoe'],
+    productTags: ['brownShoe'],
   },
   [AD_RENDER_URL_START + '1fa74' + AD_RENDER_URL_END]: {
-    product_tags: ['blueShoe'],
+    productTags: ['blueShoe'],
   },
   [AD_RENDER_URL_START + '1f3bf' + AD_RENDER_URL_END]: {
-    product_tags: ['blueShoe', 'sportsShoe'],
+    productTags: ['blueShoe', 'sportsShoe'],
   },
   [AD_RENDER_URL_START + '26f8' + AD_RENDER_URL_END]: {
-    product_tags: ['sportsShoe'],
+    productTags: ['sportsShoe'],
   },
 };
 

--- a/services/ssp/src/public/js/uc-publisher-ads-req/ad-tag.js
+++ b/services/ssp/src/public/js/uc-publisher-ads-req/ad-tag.js
@@ -1,0 +1,34 @@
+/*
+ Copyright 2022 Google LLC
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+      https://www.apache.org/licenses/LICENSE-2.0
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+(async () => {
+  const ins = document.querySelector('ins.ads');
+  const script = document.querySelector('.ssp_tag');
+  const src = new URL(script.src);
+  src.pathname = 'uc-publisher-ads-req/ad-tag.html';
+
+  const urlParams = new URLSearchParams(window.location.search);
+  const excludeProductTagValue = urlParams.get('excludeProductTag');
+  if (excludeProductTagValue) {
+    src.searchParams.append('excludeProductTag', excludeProductTagValue);
+  }
+
+  const iframe = document.createElement('iframe');
+  iframe.width = 300;
+  iframe.height = 250;
+  iframe.src = src;
+  iframe.setAttribute('scrolling', 'no');
+  iframe.setAttribute('style', 'border: none');
+  iframe.setAttribute('allow', 'attribution-reporting; run-ad-auction');
+  ins.appendChild(iframe);
+})();

--- a/services/ssp/src/public/js/uc-publisher-ads-req/decision-logic.js
+++ b/services/ssp/src/public/js/uc-publisher-ads-req/decision-logic.js
@@ -24,7 +24,7 @@ function scoreAd(
 ) {
   if (auctionConfig.sellerSignals.excludeProductTag) {
     const productTags =
-      trustedScoringSignals.renderURL[browserSignals.renderURL].product_tags;
+      trustedScoringSignals.renderURL[browserSignals.renderURL].productTags;
     if (productTags.includes(auctionConfig.sellerSignals.excludeProductTag)) {
       // Exclude ad from auction - has excluded tag
       return 0;

--- a/services/ssp/src/public/js/uc-publisher-ads-req/decision-logic.js
+++ b/services/ssp/src/public/js/uc-publisher-ads-req/decision-logic.js
@@ -1,0 +1,45 @@
+/*
+ Copyright 2022 Google LLC
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+      https://www.apache.org/licenses/LICENSE-2.0
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+function log(label, o) {
+  console.log(label, JSON.stringify(o, ' ', ' '));
+}
+
+function scoreAd(
+  adMetadata,
+  bid,
+  auctionConfig,
+  trustedScoringSignals,
+  browserSignals,
+) {
+  if (auctionConfig.sellerSignals.excludeProductTag) {
+    const productTags =
+      trustedScoringSignals.renderURL[browserSignals.renderURL].product_tags;
+    if (productTags.includes(auctionConfig.sellerSignals.excludeProductTag)) {
+      // Exclude ad from auction - has excluded tag
+      return 0;
+    }
+  }
+
+  return bid;
+}
+
+function reportResult(auctionConfig, browserSignals) {
+  log('reportResult', {auctionConfig, browserSignals});
+  sendReportTo(auctionConfig.seller + '/reporting?report=result');
+  return {
+    success: true,
+    signalsForWinner: {signalForWinner: 1},
+    reportUrl: auctionConfig.seller + '/reporting',
+  };
+}

--- a/services/ssp/src/public/js/uc-publisher-ads-req/run-ad-auction.js
+++ b/services/ssp/src/public/js/uc-publisher-ads-req/run-ad-auction.js
@@ -1,0 +1,53 @@
+/*
+ Copyright 2022 Google LLC
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+      https://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+async function getAuctionConfig() {
+  // Grab the 'excludeProductTag' param from the url
+  const queryString = window.location.search;
+  const urlParams = new URLSearchParams(queryString);
+  const excludeProductTag = urlParams.get('excludeProductTag');
+
+  // Load the auction config json
+  const auctionConfig = await getStaticAuctionConfig();
+
+  // Add the excluded product tag as the auction config seller signals
+  auctionConfig.sellerSignals = {'excludeProductTag': excludeProductTag};
+
+  return auctionConfig;
+}
+
+async function getStaticAuctionConfig() {
+  const url = new URL(location.origin);
+  url.pathname = '/uc-publisher-ads-req/auction-config.json';
+  const res = await fetch(url);
+  return res.json();
+}
+
+document.addEventListener('DOMContentLoaded', async (e) => {
+  if (navigator.runAdAuction === undefined) {
+    return console.log('Protected Audience API is not supported');
+  }
+
+  const auctionConfig = await getAuctionConfig();
+  const adAuctionResult = await navigator.runAdAuction(auctionConfig);
+  const ele = document.createElement('fencedframe');
+  ele.config = adAuctionResult;
+  ele.setAttribute('mode', 'opaque-ads');
+  ele.setAttribute('scrolling', 'no');
+  ele.width = 300;
+  ele.height = 250;
+  document.body.appendChild(ele);
+});

--- a/services/ssp/src/views/uc-publisher-ads-req/ad-tag.html.ejs
+++ b/services/ssp/src/views/uc-publisher-ads-req/ad-tag.html.ejs
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width,initial-scale=1" />
+<link rel="icon" href="" />
+<title></title>
+
+<style>
+  body {
+    margin: 0;
+    padding: 0;
+    box-sizing: border-box;
+    width: 100vw;
+    height: 100vh;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+  }
+  fencedframe {
+    border: none;
+    width: 100vw;
+    height: 100vh;
+    background-color: aliceblue;
+  }
+</style>
+
+<script src="/js/uc-publisher-ads-req/run-ad-auction.js"></script>


### PR DESCRIPTION
# Description

In this demo, we assume a publisher would like to exclude ads with certain product types. We’ll demonstrate a publisher page calling an SSP to perform a PAAPI auction, supplying product tags to exclude which have been selected by the user (e.g. “redShoe”). The SSP will exclude ads by calling their backend K/V server with the ad urls, and receiving ad metadata as JSON (e.g. {“productTags”: [“redShoe”, “shortsShoe”]}) which will be matched to the product tag to exclude.

Since PR460, this also includes;
- Requested changes from Syna
- Changes to deal with dev commit merge
- Request from Severin to parameterize urls in auction config (now being generated server side, like existing retargetting / remarking UC).
- Small nits from Kevin Lee comments in the design doc (e.g. switching tags names from sneck_case to camelCase, removing $ from var names)

Plan for after this PR submits:
- Copy code back into design doc
- Send another PR for Docusaurus changes

## Affected services

- [ ] Home
- [ x] News
- [ ] Shop
- [ ] Travel
- [ ] DSP
- [ x] SSP
- [ ] ALL