### PR TITLE
remove unused topics-server to clean codebase

### DIFF
--- a/.env
+++ b/.env
@@ -5,7 +5,7 @@ EXTERNAL_PORT=443
 PORT=8080
 
 # list of service names
-SERVICES=("home" "news" "shop" "travel" "dsp" "dsp-a" "dsp-b" "ssp" "ssp-a" "ssp-b" "idp" "topics" "topics-server" "ad-server")
+SERVICES=("home" "news" "shop" "travel" "dsp" "dsp-a" "dsp-b" "ssp" "ssp-a" "ssp-b" "idp" "ad-server")
 
 DEMO_HOST_PREFIX=privacy-sandbox-demos-
 
@@ -83,11 +83,6 @@ MOTO_NEWS_HOST=motorcycles.privacy-sandbox-demos-news.dev
 SOCCER_NEWS_HOST=soccer.privacy-sandbox-demos-news.dev
 GARDENING_NEWS_HOST=gardening.privacy-sandbox-demos-news.dev
 TOPICS_DETAIL="Topics page"
-
-## server to request topics with headers
-TOPICS_SERVER_HOST=topics-server.privacy-sandbox-demos-news.dev
-TOPICS_SERVER_URI=http://topics-server.privacy-sandbox-demos-news.dev:8080
-TOPICS_SERVER_DETAIL="Topics server"
 
 ## ad server
 AD_SERVER_HOST=privacy-sandbox-demos-ad-server.dev

--- a/cicd/.env.dev
+++ b/cicd/.env.dev
@@ -5,7 +5,7 @@ EXTERNAL_PORT=443
 PORT=8080
 
 # list of service names
-SERVICES=("home" "news" "shop" "travel" "dsp" "dsp-a" "dsp-b" "ssp" "ssp-a" "ssp-b" "idp" "topics-server" "ad-server")
+SERVICES=("home" "news" "shop" "travel" "dsp" "dsp-a" "dsp-b" "ssp" "ssp-a" "ssp-b" "idp" "ad-server")
 
 DEMO_HOST_PREFIX=privacy-sandcastle-dev-
 
@@ -84,11 +84,6 @@ MOTO_NEWS_HOST=privacy-sandcastle-dev-motorcycles.web.app
 SOCCER_NEWS_HOST=privacy-sandcastle-dev-soccer-foot.web.app
 GARDENING_NEWS_HOST=privacy-sandcastle-dev-gardening-potager.web.app
 TOPICS_DETAIL="Topics page"
-
-## server to request topics with headers
-TOPICS_SERVER_HOST=privacy-sandcastle-dev-topics-server.web.app
-TOPICS_SERVER_URI=https://privacy-sandcastle-dev-topics-server.web.app
-TOPICS_SERVER_DETAIL="Topics server"
 
 ## ad server
 AD_SERVER_HOST=privacy-sandcastle-dev-ad-server.web.app

--- a/cicd/.env.prod
+++ b/cicd/.env.prod
@@ -5,7 +5,7 @@ EXTERNAL_PORT=443
 PORT=8080
 
 # list of service names
-SERVICES=("home" "news" "shop" "travel" "dsp" "dsp-a" "dsp-b" "ssp" "ssp-a" "ssp-b" "idp" "topics" "topics-server" "ad-server")
+SERVICES=("home" "news" "shop" "travel" "dsp" "dsp-a" "dsp-b" "ssp" "ssp-a" "ssp-b" "idp" "ad-server")
 
 DEMO_HOST_PREFIX=privacy-sandbox-demos-
 
@@ -84,11 +84,6 @@ MOTO_NEWS_HOST=motorcycles.privacy-sandbox-demos-news.dev
 SOCCER_NEWS_HOST=soccer.privacy-sandbox-demos-news.dev
 GARDENING_NEWS_HOST=gardening.privacy-sandbox-demos-news.dev
 TOPICS_DETAIL="Topics page"
-
-## server to request topics with headers
-TOPICS_SERVER_HOST=topics-server.privacy-sandbox-demos-news.dev
-TOPICS_SERVER_URI=https://topics-server.privacy-sandbox-demos-news.dev
-TOPICS_SERVER_DETAIL="Topics server"
 
 ## ad server
 AD_SERVER_HOST=privacy-sandbox-demos-ad-server.dev

--- a/cicd/cloudbuild.yaml
+++ b/cicd/cloudbuild.yaml
@@ -292,23 +292,6 @@ steps:
         echo $${ENV_VARS}
         gcloud run deploy ad-server --image ${_LOCATION}-docker.pkg.dev/$PROJECT_ID/${_REPOSITORY}/ad-tech:$COMMIT_SHA --platform managed --region ${_LOCATION} --memory 2Gi --min-instances 1 --allow-unauthenticated --command npm --args=run,start,--service=ad-server,--project_env=${_PROJECT_ENV} --set-env-vars "^@^$${ENV_VARS}"
 
-  # TOPICS-SERVER
-  # Deploy container image to Cloud Run
-  - name: "gcr.io/cloud-builders/gcloud"
-    id: deploy-topics-server
-    waitFor:
-      - push-ad-tech
-      - read-env
-    entrypoint: "bash"
-    args:
-      - "-c"
-      - |
-        ENV_VARS=$(cat /workspace/env_vars.txt)
-        HOSTNAME_ENV="HOSTNAME=$(grep "TOPICS_SERVER_HOST=" cicd/.env.${_PROJECT_ENV} | cut -d '=' -f2)"
-        ENV_VARS=$${HOSTNAME_ENV}@$${ENV_VARS}
-        echo $${ENV_VARS}
-        gcloud run deploy topics-server --image ${_LOCATION}-docker.pkg.dev/$PROJECT_ID/${_REPOSITORY}/ad-tech:$COMMIT_SHA --platform managed --region ${_LOCATION} --memory 2Gi --min-instances 1 --allow-unauthenticated --set-env-vars "^@^$${ENV_VARS}"
-
   # TRAVEL
   # Build the container image
   - name: "gcr.io/cloud-builders/docker"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,7 +9,6 @@ volumes:
   ssp_node_modules:
   ssp_a_node_modules:
   ssp_b_node_modules:
-  topics_server_node_modules:
   ad_server_node_modules:
 
 services:
@@ -165,19 +164,6 @@ services:
     networks:
       - adnetwork
 
-  topics-server:
-    image: gcr.io/privacy-sandbox-demos/ad-tech:latest
-    build: ./services/ad-tech
-    container_name: "sandcastle_topics_server"
-    hostname: ${TOPICS_SERVER_HOST:?err}
-    env_file:
-      - .env
-    volumes:
-      - ./services/ad-tech:/workspace
-      - topics_server_node_modules:/workspace/node_modules
-    networks:
-      - adnetwork
-
   nginx:
     image: nginx:1.22.1-alpine
     container_name: "proxy"
@@ -208,7 +194,6 @@ services:
       - dsp-b
       - ad-server
       - collector
-      - topics-server
 
 networks:
   adnetwork:

--- a/firebase.json
+++ b/firebase.json
@@ -262,25 +262,6 @@
       ]
     },
     {
-      "target": "topics-server",
-      "public": "services/ad-tech/src/public",
-      "ignore": [
-        "firebase.json",
-        "**/.*",
-        "**/**",
-        "**/node_modules/**"
-      ],
-      "rewrites": [
-        {
-          "source": "**",
-          "run": {
-            "serviceId": "topics-server",
-            "region": "us-central1"
-          }
-        }
-      ]
-    },
-    {
       "target": "ad-server",
       "public": "services/ad-tech/src/public",
       "ignore": [

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -235,23 +235,6 @@ server {
 
 server {
   listen 443 ssl;
-  server_name ${TOPICS_SERVER_HOST};
-
-  ssl_certificate     /cert/${TOPICS_SERVER_HOST}.pem;
-  ssl_certificate_key /cert/${TOPICS_SERVER_HOST}-key.pem;
-
-  proxy_set_header Host $host;
-  proxy_set_header X-Real-IP $remote_addr;
-  proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-  proxy_set_header X-Forwarded-Proto $scheme;
-
-  location / {
-    proxy_pass http://topics-server:${PORT}/;
-  }
-}
-
-server {
-  listen 443 ssl;
   server_name ${AD_SERVER_HOST};
 
   ssl_certificate     /cert/${AD_SERVER_HOST}.pem;


### PR DESCRIPTION
# Description

This changes removes all references to topics-server. This service is not used and won't be used. We refactored the code so that ad-tech service will include functionalities to [Observe and Access Topics](https://developers.google.com/privacy-sandbox/private-advertising/topics/web/implement). In future use cases, SSP/DSP will observe topics and use these information in auction/bidding signals.

## Related Issue

NA

## Affected services

- [x] topics-server 

Other:
