### PR TITLE
Add github-repo-stats workflow file

### DIFF
--- a/.github/workflows/github-repo-stats.yml
+++ b/.github/workflows/github-repo-stats.yml
@@ -1,0 +1,19 @@
+name: github-repo-stats
+
+on:
+  schedule:
+    # Run this once per day, towards the end of the day for keeping the most
+    # recent data point most meaningful (hours are interpreted in UTC).
+    - cron: "0 23 * * *"
+  workflow_dispatch: # Allow for running this manually.
+
+jobs:
+  j1:
+    name: github-repo-stats
+    runs-on: ubuntu-latest
+    steps:
+      - name: run-ghrs
+        # Use latest release.
+        uses: jgehrcke/github-repo-stats@RELEASE
+        with:
+          ghtoken: ${{ secrets.ghrs_github_api_token }}


### PR DESCRIPTION
# Description

Following the instructions at https://github.com/jgehrcke/github-repo-stats/wiki/Tutorial to install GitHub repo stats.

Objective is to collect GitHub repo analytics/insights for > 14days

Note : this change will only be active once merged with the default branch (main)

## Related Issue

-  NA

## Affected services

- [ ] Home
- [ ] News
- [ ] Shop
- [ ] Travel
- [ ] DSP
- [ ] SSP
- [ ] ALL

Other:
- GitHub repository governance
