### PR TITLE
add docker-compose down command to clean npm script

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "build": "docker-compose build",
     "docker": "docker-compose build && docker-compose up",
     "deploy": "./scripts/cloudrun_deploy.sh && ./scripts/firebase_deploy.sh",
-    "clean": "docker-compose rm -f && docker volume prune -f && docker image prune -f && docker rmi -f $(docker images -q)",
+    "clean": "docker-compose rm -f && docker volume prune -f && docker image prune -f && docker rmi -f $(docker images -q) && docker-compose down -v",
     "fmt": "pre-commit run --all-files"
   },
   "devDependencies": {


### PR DESCRIPTION
# Description

Adds the `docker-compose down -v` command to `npm run clean`. This removes stale node_modules volumes that could cause inconsistencies when switching between branches or versions. 

## Related Issue

- Fixes issue where packages within the ad-tech service were not able to be found, due to stale node_modules docker volumes. Adding this command to clean ensures that all docker components are purged. 

## Affected services

- [ ] Home
- [ ] News
- [ ] Shop
- [ ] Travel
- [ ] DSP
- [ ] SSP
- [X] ALL

Other:
