### PR TITLE
Feature/bidding and auction

### DIFF
--- a/.env
+++ b/.env
@@ -5,7 +5,7 @@ EXTERNAL_PORT=443
 PORT=8080
 
 # list of service names
-SERVICES=("home" "news" "shop" "travel" "dsp" "dsp-a" "dsp-b" "ssp" "ssp-a" "ssp-b" "idp" "ad-server")
+SERVICES=("home" "news" "shop" "travel" "dsp" "dsp-a" "dsp-b", "dsp-x", "dsp-y", "ssp" "ssp-a" "ssp-b" "idp" "ad-server")
 
 DEMO_HOST_PREFIX=privacy-sandbox-demos-
 
@@ -53,6 +53,16 @@ DSP_B_HOST=privacy-sandbox-demos-dsp-b.dev
 DSP_B_URI=http://privacy-sandbox-demos-dsp-b.dev:8080
 DSP_B_TOKEN=""
 DSP_B_DETAIL="Ad-Platform: DSP-B for advertiser"
+
+DSP_X_HOST=privacy-sandbox-demos-dsp-x.dev
+DSP_X_URI=http://privacy-sandbox-demos-dsp-x.dev:8080
+DSP_X_TOKEN=""
+DSP_X_DETAIL="Ad-Platform DSP-X for advertiser"
+
+DSP_Y_HOST=privacy-sandbox-demos-dsp-y.dev
+DSP_Y_URI=http://privacy-sandbox-demos-dsp-y.dev:8080
+DSP_Y_TOKEN=""
+DSP_Y_DETAIL="Ad-Platform DSP-Y for advertiser"
 
 ## ssp
 SSP_HOST=privacy-sandbox-demos-ssp.dev

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,6 +6,8 @@ volumes:
   dsp_node_modules:
   dsp_a_node_modules:
   dsp_b_node_modules:
+  dsp_x_node_modules:
+  dsp_y_node_modules:
   ssp_node_modules:
   ssp_a_node_modules:
   ssp_b_node_modules:
@@ -97,6 +99,32 @@ services:
     volumes:
       - ./services/ad-tech:/workspace
       - dsp_b_node_modules:/workspace/node_modules
+    networks:
+      - adnetwork
+
+  dsp-x:
+    image: gcr.io/privacy-sandbox-demos/ad-tech:latest
+    build: ./services/ad-tech
+    container_name: "sandcastle_dsp_x"
+    hostname: ${DSP_X_HOST:?err}
+    env_file:
+      - .env
+    volumes:
+      - ./services/ad-tech:/workspace
+      - dsp_x_node_modules:/workspace/node_modules
+    networks:
+      - adnetwork
+
+  dsp-y:
+    image: gcr.io/privacy-sandbox-demos/ad-tech:latest
+    build: ./services/ad-tech
+    container_name: "sandcastle_dsp_y"
+    hostname: ${DSP_Y_HOST:?err}
+    env_file:
+      - .env
+    volumes:
+      - ./services/ad-tech:/workspace
+      - dsp_y_node_modules:/workspace/node_modules
     networks:
       - adnetwork
 
@@ -192,6 +220,8 @@ services:
       - dsp
       - dsp-a
       - dsp-b
+      - dsp-x
+      - dsp-y
       - ad-server
       - collector
 

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -122,6 +122,38 @@ server {
 
 server {
   listen 443 ssl;
+  server_name ${DSP_X_HOST};
+
+  ssl_certificate     /cert/${DSP_X_HOST}.pem;
+  ssl_certificate_key /cert/${DSP_X_HOST}-key.pem;
+  proxy_set_header Host $host;
+  proxy_set_header X-Real-IP $remote_addr;
+  proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+  proxy_set_header X-Forwarded-Proto $scheme;
+
+  location / {
+    proxy_pass http://dsp-x:${PORT}/;
+  }
+}
+
+server {
+  listen 443 ssl;
+  server_name ${DSP_Y_HOST};
+
+  ssl_certificate     /cert/${DSP_Y_HOST}.pem;
+  ssl_certificate_key /cert/${DSP_Y_HOST}-key.pem;
+  proxy_set_header Host $host;
+  proxy_set_header X-Real-IP $remote_addr;
+  proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+  proxy_set_header X-Forwarded-Proto $scheme;
+
+  location / {
+    proxy_pass http://dsp-y:${PORT}/;
+  }
+}
+
+server {
+  listen 443 ssl;
   server_name ${SSP_HOST};
 
   ssl_certificate     /cert/${SSP_HOST}.pem;

--- a/services/ad-tech/src/controllers/key-value-store.ts
+++ b/services/ad-tech/src/controllers/key-value-store.ts
@@ -27,7 +27,6 @@ export class KeyValueStore {
     defaultValues: string[][] = [],
     resetIntervalInMins: number = 30,
   ) {
-    console.log('Initializing in-memory key value store.', {defaultValues});
     this.defaultData = defaultValues;
     this.rewriteDefaults();
     setInterval(this.rewriteDefaults, 1000 * 60 * resetIntervalInMins);

--- a/services/ad-tech/src/lib/constants.ts
+++ b/services/ad-tech/src/lib/constants.ts
@@ -47,6 +47,14 @@ export const {
   DSP_B_DETAIL,
   DSP_B_URI,
 
+  DSP_X_HOST,
+  DSP_X_DETAIL,
+  DSP_X_URI,
+
+  DSP_Y_HOST,
+  DSP_Y_DETAIL,
+  DSP_Y_URI,
+
   SSP_HOST,
   SSP_DETAIL,
   SSP_URI,

--- a/services/ad-tech/src/public/js/dsp/usecase/bidding-and-auction/dsp-tag.js
+++ b/services/ad-tech/src/public/js/dsp/usecase/bidding-and-auction/dsp-tag.js
@@ -1,0 +1,120 @@
+/*
+ Copyright 2022 Google LLC
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+      https://www.apache.org/licenses/LICENSE-2.0
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+/**
+ * Where is this script used:
+ *   This is the only script that is included on the advertiser's page, and is
+ *   responsible for orchestrating other ad-tech modules as needed.
+ *
+ * What does this script do:
+ *   This is the main tag for an ad buyer or a Demand Side Platform - DSP. This
+ *   script loads additional iframes from its own origin for various use-cases.
+ *   This script contains a few helper functions that help copy over
+ *   first-party context attached either to the top-level page URL or to the
+ *   current script tag.
+ */
+
+(async () => {
+    // ********************************************************
+    // HELPER FUNCTIONS
+    // ********************************************************
+    /** Injects an iframe using the current script's reference. */
+    const injectIframe = (src, options) => {
+      if (!src) {
+        return;
+      }
+      const $iframe = document.createElement('iframe');
+      $iframe.src = src;
+      $iframe.width = 1;
+      $iframe.height = 1;
+      $iframe.async = true;
+      $iframe.defer = true;
+      if (options && 'object' === typeof options) {
+        for (const [key, value] of Object.entries(options)) {
+          $iframe.setAttribute(key, value);
+        }
+      }
+      console.log('[PSDemo] Ad buyer injecting iframe', {src, $iframe});
+      const $script = document.currentScript;
+      $script.parentElement.insertBefore($iframe, $script);
+    };
+  
+    /** Returns additional page context data to be captured. */
+    const getPageContextData = () => {
+      const pageContext = {
+        title: document.title,
+        isMobile: navigator.userAgentData.mobile,
+        platform: navigator.userAgentData.platform,
+      };
+      return pageContext;
+    };
+  
+    /** Copies first-party context onto iframe URL. */
+    const getServerUrlWithPageContext = (pathname) => {
+      if (!pathname) {
+        return;
+      }
+      // Construct iframe URL using current script origin.
+      const $script = document.currentScript;
+      const src = new URL($script.src);
+      src.pathname = pathname;
+      // Append query parameters from script dataset context.
+      for (const datakey in $script.dataset) {
+        src.searchParams.append(datakey, $script.dataset[datakey]);
+      }
+      if (!$script.dataset.advertiser) {
+        // Manually attach advertiser if missing.
+        src.searchParams.append('advertiser', location.hostname);
+      }
+      // Append query params from page URL.
+      const currentUrl = new URL(location.href);
+      for (const [key, value] of currentUrl.searchParams) {
+        src.searchParams.append(key, value);
+      }
+      // Append additional page context data.
+      for (const [key, value] of Object.entries(getPageContextData())) {
+        src.searchParams.append(key, value);
+      }
+      return src;
+    };
+  
+    // ********************************************************
+    // MAIN FUNCTION
+    // ********************************************************
+    (() => {
+      /** Inject DSP iframe to execute scripts in ad-tech's origin context.
+       */
+      injectIframe(
+        /* src= */ getServerUrlWithPageContext(
+          /* pathname= */ 'dsp/dsp-advertiser-iframe-bidding-and-auction.html',
+        ),
+        /* options= */ {
+          allow: 'join-ad-interest-group',
+          browsingTopics: '',
+        },
+      );
+  
+      /** Additional iframes to be injected go here... */
+  
+      /** Test only */
+      if (false) {
+        // Private Aggregation test
+        injectIframe(
+          /* src= */ getServerUrlWithPageContext(
+            /* pathname= */ 'dsp/test-private-aggregation.html',
+          ),
+        );
+      }
+    })();
+  })();
+  

--- a/services/ad-tech/src/public/js/dsp/usecase/bidding-and-auction/join-ad-interest-group.js
+++ b/services/ad-tech/src/public/js/dsp/usecase/bidding-and-auction/join-ad-interest-group.js
@@ -1,0 +1,63 @@
+/*
+ Copyright 2022 Google LLC
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+      https://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+/**
+ * Where is this script used:
+ *   This script is loaded in the join-ad-interest-group.html iframe.
+ *
+ * What does this script do:
+ *   This script starts by querying the ad-tech server (same origin to current
+ *   script) to retrieve interest group metadata to use with the Protected
+ *   Audience API on the client-side. First-party context is also included in
+ *   this request to the ad-tech server which includes URL query parameters
+ *   from the top-level page as well as any script dataset context directly
+ *   attached to the DSP tag.
+ */
+
+(() => {
+    /** Sends first-party context to server to retrieve interest group metadata. */
+    getInterestGroupFromServer = async () => {
+      const currentUrl = new URL(location.href);
+      const interestGroupUrl = new URL(location.origin);
+        interestGroupUrl.pathname = '/dsp/interest-group-bidding-and-auction.json';
+      // Copy query params from current context.
+      for (const [key, value] of currentUrl.searchParams) {
+        interestGroupUrl.searchParams.append(key, value);
+      }
+      // TODO: Consider using Topics API for choosing Ads
+      // const topics = await document.browsingTopics?
+      // console.log({ topics })
+      // interestGroupUrl.searchParams.append('topics', topics);
+      const res = await fetch(interestGroupUrl, {browsingTopics: true});
+      if (res.ok) {
+        return res.json();
+      }
+    };
+  
+    document.addEventListener('DOMContentLoaded', async () => {
+      if (navigator.joinAdInterestGroup === undefined) {
+        console.log('[PSDemo] Protected Audience API is not supported.');
+        return;
+      }
+        const interestGroup = await getInterestGroupFromServer();
+        console.log('[PSDemo] Joining interest group: ', {interestGroup});
+        const kSecsPerDay = 3600 * 24 * 30;
+        console.log(
+          await navigator.joinAdInterestGroup(interestGroup, kSecsPerDay),
+        );
+    });
+  })();
+  

--- a/services/ad-tech/src/routes/dsp/buyer-router.ts
+++ b/services/ad-tech/src/routes/dsp/buyer-router.ts
@@ -16,6 +16,7 @@ import {HOSTNAME} from '../../lib/constants.js';
 import {getTemplateVariables} from '../../lib/common-utils.js';
 import {
   getInterestGroup,
+  getInterestGroupBiddingAndAuction,
   TargetingContext,
 } from '../../lib/interest-group-helper.js';
 
@@ -41,11 +42,26 @@ BuyerRouter.get(
     );
   },
 );
+BuyerRouter.get(
+  '/dsp-advertiser-iframe-bidding-and-auction.html',
+  async (req: Request, res: Response) => {
+    res.render(
+      'dsp/usecase/bidding-and-auction/dsp-advertiser-iframe',
+      getTemplateVariables('Join Ad Interest Group'),
+    );
+  },
+);
 
 /** Returns the interest group to join on an advertiser page. */
 BuyerRouter.get('/interest-group.json', async (req: Request, res: Response) => {
   const targetingContext = assembleTargetingContext(req.query);
   res.json(getInterestGroup(targetingContext));
+});
+
+/** Returns the interest group to join on an advertiser page. */
+BuyerRouter.get('/interest-group-bidding-and-auction.json', async (req: Request, res: Response) => {
+  const targetingContext = assembleTargetingContext(req.query);
+  res.json(getInterestGroupBiddingAndAuction(targetingContext));
 });
 
 /** Returns the updated interest group, usually daily, may be overridden. */

--- a/services/ad-tech/src/views/dsp/usecase/bidding-and-auction/dsp-advertiser-iframe.ejs
+++ b/services/ad-tech/src/views/dsp/usecase/bidding-and-auction/dsp-advertiser-iframe.ejs
@@ -9,7 +9,7 @@
   <title></title>
 
   <%/* Script to add user to an interest group. */%>
-  <script src="<%= `https://${HOSTNAME}:${EXTERNAL_PORT}/js/dsp/join-ad-interest-group.js` %>">
+  <script src="<%= `https://${HOSTNAME}:${EXTERNAL_PORT}/js/dsp/usecase/bidding-and-auction/join-ad-interest-group.js` %>">
   </script>
 </head>
 

--- a/services/shop/src/index.ts
+++ b/services/shop/src/index.ts
@@ -22,6 +22,8 @@ import {
   DSP_HOST,
   DSP_A_HOST,
   DSP_B_HOST,
+  DSP_X_HOST,
+  DSP_Y_HOST,
   EXTERNAL_PORT,
   PORT,
   SHOP_DETAIL,
@@ -131,22 +133,40 @@ app.get('/ads/:id?', async (req: Request, res: Response) => {
 app.get('/items/:id', async (req: Request, res: Response) => {
   const {id} = req.params;
   const item = await getItem(id);
-
-  const DSP_TAG_URL = new URL(
-    `https://${DSP_HOST}:${EXTERNAL_PORT}/js/dsp/dsp-tag.js`,
-  );
-  const DSP_A_TAG_URL = new URL(
-    `https://${DSP_A_HOST}:${EXTERNAL_PORT}/js/dsp/dsp-tag.js`,
-  );
-  const DSP_B_TAG_URL = new URL(
-    `https://${DSP_B_HOST}:${EXTERNAL_PORT}/js/dsp/dsp-tag.js`,
-  );
+  const { auctionType } = req.query;
+  const DSP_TAG_URLS = (auctionType : string) => {
+    const urls = [];
+    if(auctionType == 'ba'){
+      urls.push(
+        new URL(
+        `https://${DSP_HOST}:${EXTERNAL_PORT}/js/dsp/dsp-tag.js`),
+        new URL(
+        `https://${DSP_A_HOST}:${EXTERNAL_PORT}/js/dsp/dsp-tag.js`),
+        new URL(
+        `https://${DSP_B_HOST}:${EXTERNAL_PORT}/js/dsp/dsp-tag.js`),
+        new URL(
+        `https://${DSP_X_HOST}:${EXTERNAL_PORT}/js/dsp/dsp-tag.js`),
+        new URL(
+        `https://${DSP_Y_HOST}:${EXTERNAL_PORT}/js/dsp/dsp-tag.js`),
+        );
+    } else {
+      urls.push(
+        new URL(
+        `https://${DSP_HOST}:${EXTERNAL_PORT}/js/dsp/dsp-tag.js`),
+        new URL(
+        `https://${DSP_A_HOST}:${EXTERNAL_PORT}/js/dsp/dsp-tag.js`),
+        new URL(
+        `https://${DSP_B_HOST}:${EXTERNAL_PORT}/js/dsp/dsp-tag.js`),
+        );
+    }
+      return urls.toString();
+    }
+  const DSP_TAGS_FLAT= DSP_TAG_URLS(auctionType);
+  console.log(DSP_TAGS_FLAT);
 
   res.render('item', {
+    DSP_TAGS_FLAT,
     item,
-    DSP_TAG_URL,
-    DSP_A_TAG_URL,
-    DSP_B_TAG_URL,
     SHOP_HOST,
   });
 });

--- a/services/shop/src/index.ts
+++ b/services/shop/src/index.ts
@@ -99,6 +99,8 @@ app.locals = {
       new URL(`https://${DSP_HOST}:${EXTERNAL_PORT}`),
       new URL(`https://${DSP_A_HOST}:${EXTERNAL_PORT}`),
       new URL(`https://${DSP_B_HOST}:${EXTERNAL_PORT}`),
+      new URL(`https://${DSP_X_HOST}:${EXTERNAL_PORT}`),
+      new URL(`https://${DSP_Y_HOST}:${EXTERNAL_PORT}`),
       new URL(`https://${SSP_HOST}:${EXTERNAL_PORT}`),
       new URL(`https://${SSP_A_HOST}:${EXTERNAL_PORT}`),
       new URL(`https://${SSP_B_HOST}:${EXTERNAL_PORT}`),
@@ -131,43 +133,44 @@ app.get('/ads/:id?', async (req: Request, res: Response) => {
 });
 
 app.get('/items/:id', async (req: Request, res: Response) => {
+  const { usecase } = req.query;
   const {id} = req.params;
   const item = await getItem(id);
-  const { auctionType } = req.query;
-  const DSP_TAG_URLS = (auctionType : string) => {
-    const urls = [];
-    if(auctionType == 'ba'){
-      urls.push(
-        new URL(
-        `https://${DSP_HOST}:${EXTERNAL_PORT}/js/dsp/dsp-tag.js`),
-        new URL(
-        `https://${DSP_A_HOST}:${EXTERNAL_PORT}/js/dsp/dsp-tag.js`),
-        new URL(
-        `https://${DSP_B_HOST}:${EXTERNAL_PORT}/js/dsp/dsp-tag.js`),
-        new URL(
-        `https://${DSP_X_HOST}:${EXTERNAL_PORT}/js/dsp/dsp-tag.js`),
-        new URL(
-        `https://${DSP_Y_HOST}:${EXTERNAL_PORT}/js/dsp/dsp-tag.js`),
-        );
-    } else {
-      urls.push(
-        new URL(
-        `https://${DSP_HOST}:${EXTERNAL_PORT}/js/dsp/dsp-tag.js`),
-        new URL(
-        `https://${DSP_A_HOST}:${EXTERNAL_PORT}/js/dsp/dsp-tag.js`),
-        new URL(
-        `https://${DSP_B_HOST}:${EXTERNAL_PORT}/js/dsp/dsp-tag.js`),
-        );
-    }
-      return urls.toString();
-    }
-  const DSP_TAGS_FLAT= DSP_TAG_URLS(auctionType);
-  console.log(DSP_TAGS_FLAT);
+  let DSP_TAG_URL = new URL(
+    `https://${DSP_HOST}:${EXTERNAL_PORT}/js/dsp/dsp-tag.js`,
+  );
+  let DSP_A_TAG_URL = new URL(
+    `https://${DSP_A_HOST}:${EXTERNAL_PORT}/js/dsp/dsp-tag.js`,
+  );
+  let DSP_B_TAG_URL = new URL(
+      `https://${DSP_B_HOST}:${EXTERNAL_PORT}/js/dsp/dsp-tag.js`,
+  );
+  let DSP_X_TAG_URL;
+  let DSP_Y_TAG_URL; 
 
+  if(usecase == 'ba'){
+    DSP_A_TAG_URL = new URL(
+      `https://${DSP_A_HOST}:${EXTERNAL_PORT}/js/dsp/dsp-tag.js`,
+    );
+     DSP_B_TAG_URL = new URL(
+        `https://${DSP_B_HOST}:${EXTERNAL_PORT}/js/dsp/dsp-tag.js`,
+    );
+    DSP_X_TAG_URL = new URL(
+        `https://${DSP_X_HOST}:${EXTERNAL_PORT}/js/dsp/usecase/bidding-and-auction/dsp-tag.js`,
+    );
+    DSP_Y_TAG_URL = new URL(
+        `https://${DSP_Y_HOST}:${EXTERNAL_PORT}/js/dsp/usecase/bidding-and-auction/dsp-tag.js`,
+    );
+  }
   res.render('item', {
-    DSP_TAGS_FLAT,
+    DSP_A_TAG_URL,
+    DSP_B_TAG_URL,
+    DSP_X_TAG_URL,
+    DSP_Y_TAG_URL,
+    DSP_TAG_URL,
     item,
     SHOP_HOST,
+    usecase,
   });
 });
 

--- a/services/shop/src/lib/constants.ts
+++ b/services/shop/src/lib/constants.ts
@@ -40,6 +40,12 @@ export const {
   DSP_B_HOST,
   DSP_B_DETAIL,
 
+  DSP_X_HOST,
+  DSP_X_DETAIL,
+
+  DSP_Y_HOST,
+  DSP_Y_DETAIL,
+
   SSP_HOST,
   SSP_DETAIL,
 

--- a/services/shop/src/views/item.ejs
+++ b/services/shop/src/views/item.ejs
@@ -89,9 +89,15 @@
         scriptEl.dataset.itemId = '<%= item.id %>'
         return scriptEl
       }
-      document.body.appendChild(buildDspScriptTag('<%= DSP_TAG_URL %>'));
-      document.body.appendChild(buildDspScriptTag('<%= DSP_A_TAG_URL %>'));
-      document.body.appendChild(buildDspScriptTag('<%= DSP_B_TAG_URL %>'));
+      switch ('<%= usecase %>'){
+        case 'ba':
+          document.body.appendChild(buildDspScriptTag('<%= DSP_X_TAG_URL %>'));
+          document.body.appendChild(buildDspScriptTag('<%= DSP_Y_TAG_URL %>'));
+        default: 
+          document.body.appendChild(buildDspScriptTag('<%= DSP_TAG_URL %>'));
+          document.body.appendChild(buildDspScriptTag('<%= DSP_A_TAG_URL %>'));
+          document.body.appendChild(buildDspScriptTag('<%= DSP_B_TAG_URL %>'));
+      }
     </script>
   </body>
 </html>


### PR DESCRIPTION
**Prior to creating a pull request, please follow all the steps in the [contributing guide](CONTRIBUTING.md).**

# Description

- Added DSP-X and DSP-Y participants to generate B&A payload optimized interest groups only when the `?usecase=ba` query parameter is provided 
- There's a fair amount of duplicated files to ensure the payload optimization for DSP-X and DSP-Y are not reflected in DSP-A or DSP-B for the demo. The logic is split up on the news page where each set of DSPs have a separate tag

## Affected services

- [ ] Home
- [ ] News
- [X] Shop
- [ ] Travel
- [X] DSP
- [ ] SSP
- [ ] ALL


