### PR TITLE
[github repo] disable pre-commit.ci autofix_prs

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,6 +15,15 @@
 # See https://pre-commit.com for more information
 # See https://pre-commit.com/hooks.html for more hooks
 
+ci:
+  autofix_commit_msg: "[pre-commit.ci] auto fixes from pre-commit.com hooks"
+  autofix_prs: false
+  autoupdate_branch: "dev"
+  autoupdate_commit_msg: "[pre-commit.ci] pre-commit autoupdate"
+  autoupdate_schedule: quarterly
+  skip: []
+  submodules: false
+
 fail_fast: true
 repos:
   - repo: https://github.com/pre-commit/mirrors-prettier
@@ -36,7 +45,3 @@ repos:
     hooks:
       - id: markdownlint-cli2
         name: lint markdown
-ci:
-  autofix_prs: false
-  autoupdate_branch: dev
-  autoupdate_schedule: monthly


### PR DESCRIPTION
# Description

We don't want pre-commit.ci to auto fix PRs because commit from pre-commit.ci would trigger the cla/google polcy.

## Related Issue

- The previous config did not seem to work. applying the config suggested here : https://pre-commit.ci/

## Affected services

- [ ] Home
- [ ] News
- [ ] Shop
- [ ] Travel
- [ ] DSP
- [ ] SSP
- [ ] ALL

Other:
- GitHub Repository
