### PR TITLE
[doc] add instruction and scripts to use podman as an alternative to …

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,14 +22,18 @@ to extend and modify the code for your own needs.
 This repository contains :
 
 - A set of applications/services deployable as container images
-- Deployment scripts
-- [Instructions for deploying and running the demos in your local environment with Docker](docs/deploy-to-linux-docker.md)
-- [Instructions for deploying and running the demos on Google Cloud Platform](docs/deploy-to-gcp.md)
-- [A list of codebase dependencies to prepare for development](docs/dependencies.md)
-- Development framework to contribute to the project
+- A set of scripts and configuration files for local deployment and cloud deployment
+- Documentation :
+  - [Instructions for deploying and running the demos in your local environment with Docker](docs/deploy-to-linux-docker.md)
+  - [Instructions for deploying and running the demos in your local environment with Podman](docs/deploy-to-linux-podman.md)
+  - [Instructions for deploying and running the demos on Google Cloud Platform](docs/deploy-to-gcp.md)
+  - [A list of codebase dependencies to prepare for development](docs/dependencies.md)
 
-If you are a developer we recommend you follow the [deployment instructions](docs/deploy-to-linux-docker.md). If you are simply curious, we recommend
-you have a look at our [Google-hosted instances](https://privacy-sandbox-demos.dev) to quickly start learning and experimenting.
+If you are a developer we recommend you follow the deployment instructions either with [Docker](docs/deploy-to-linux-docker.md) or
+[Podman](docs/deploy-to-linux-podman.md).
+
+If you are simply curious, we recommend you have a look at our [Google-hosted instances](https://privacy-sandbox-demos.dev) to quickly start learning
+and experimenting.
 
 ## Use Cases
 

--- a/docs/deploy-to-linux-podman.md
+++ b/docs/deploy-to-linux-podman.md
@@ -8,13 +8,24 @@ your change and/or make pull requests.
 
 The following packages must be installed
 
-- [docker](https://docs.docker.com/engine/install/)
-- [docker-compose](https://docs.docker.com/compose/install/)
+- [podman](https://podman.io/get-started). We recommend to configure podman in a
+  [rootless environment](https://github.com/containers/podman/blob/main/docs/tutorials/rootless_tutorial.md)
+- [podman-compose](https://github.com/containers/podman-compose)
 - npm
 - git
 - [mkcert](https://github.com/FiloSottile/mkcert)
 
 ## Network Setup
+
+Allow non root services to use port 443
+
+To run the containers with podman rootless we will need to allow non-root services to use ports below 1024.
+
+Edit /etc/sysctl.conf file as root and add (e.g. : sudo nano /etc/sysctl.conf )
+
+net.ipv4.ip_unprivileged_port_start=443
+
+Then apply changes: sudo sysctl -p
 
 ### Domain Name / URL
 
@@ -167,24 +178,24 @@ npm run build
 ### Run start scripts
 
 ```sh
-# Build and run the docker containers (docker must be run with root permission) :
-sudo npm run start
+# Build and run the containers :
+npm run podman-start
 ```
 
 Open the home page: <https://privacy-sandbox-demos-home.dev>
 
 ## Stop your local development environment
 
-docker-compose can stop and remove the containers. In a new terminal run :
+podman-compose can stop and remove the containers. In a new terminal run :
 
 ```sh
-sudo npm run stop
+npm run podman-stop
 ```
 
 If for some reason you only want to stop/remove one container run :
 
 ```sh
-sudo docker-compose down <service_name>
+podman-compose down <service_name>
 ```
 
 ## Cleanup your containers images & volumes
@@ -195,10 +206,10 @@ have mounted your local file system `./services/xxx` to the container `/workspac
 Changes to static files should be immediate, however for typescript or compiled binaries you will have to restart your container or run again the
 build/start script from within the container.
 
-The easiest way is to restart the container using docker-compose and specify the services you wish to restart (dsp, ssp etc.)
+The easiest way is to restart the container using podman-compose and specify the services you wish to restart (dsp, ssp etc.)
 
 ```sh
-sudo docker-compose restart [SERVICE...]
+podman-compose restart [SERVICE...]
 ```
 
 If you have modified and added new dependencies (package.json or go.mod etc), you will also have to rebuild the container image. For
@@ -209,13 +220,16 @@ container. But as a side effect, dependencies may not be refreshed properly.
 To start again from a fresh environment, we are providing the following shortcut to cleanup all images, volumes :
 
 ```sh
-sudo npm run clean
+npm run podman-clean
 
-# equivalent of docker-compose down --volumes && docker-compose rm --volumes --force && docker volume prune --force && docker image prune -f && docker rmi -f $(docker images -q)
+# equivalent of podman-compose down --volumes && podman volume prune --force && podman image prune --all --force && podman rmi --all --force
 ```
 
 Alternatively you can run the commands below for a specific service :
 
 ```sh
-sudo docker-compose down --volumes <service_name>
+podman-compose down --volumes <service-name>
+podman volume prune --force <service-name>
+podman image prune --force <service-name>
+podman rmi --force <service-name>
 ```

--- a/package.json
+++ b/package.json
@@ -4,13 +4,18 @@
   "license": "apache-2.0",
   "description": "Privacy Sandbox Demos: Mixed demo of Privacy Sandbox APIs",
   "scripts": {
-    "start": "npm run docker",
     "cert": "cd nginx/cert && ./mkcert.sh",
+    "fmt": "pre-commit run --all-files",
+    "//": "block of commands for running containers with docker & docker-compose. uncomment to use it",
+    "start": "docker docker-compose up",
+    "stop": "docker-compose down --timeout 1",
     "build": "docker-compose build",
-    "docker": "docker-compose build && docker-compose up",
-    "deploy": "./scripts/cloudrun_deploy.sh && ./scripts/firebase_deploy.sh",
-    "clean": "docker-compose rm -f && docker volume prune -f && docker image prune -f && docker rmi -f $(docker images -q) && docker-compose down -v",
-    "fmt": "pre-commit run --all-files"
+    "clean": "docker-compose down --volumes && docker-compose rm --volumes --force && docker volume prune --force && docker image prune -f && docker rmi -f $(docker images -q)",
+    "//": "block of commands for running containers with podman & podman-compose",
+    "podman-start": "podman-compose up",
+    "podman-stop": "podman-compose down --timeout 1",
+    "podman-build": "podman-compose build",
+    "podman-clean": "podman-compose down --volumes && podman volume prune --force && podman image prune --all --force && podman rmi --all --force"
   },
   "devDependencies": {
     "firebase-tools": "^11.23.0",

--- a/setup.sh
+++ b/setup.sh
@@ -12,4 +12,4 @@ npm run build
 
 cd ../..
 
-sudo npm run start
+echo "you are ready to turn on the stack. use <npm run start> or <sudo npm run start>"


### PR DESCRIPTION
# Description

- Update the linux-docker documentation
- Add linux-podman documentation as an alternative to Docker
- Add shortcuts in package.json for running the stack with podman & podman-compose. Commands are prefixed with "podman-"

## Related Issue


## Affected services

- [ ] Home
- [ ] News
- [ ] Shop
- [ ] Travel
- [ ] DSP
- [ ] SSP
- [ ] ALL

Other:
- Repository