### PR TITLE
Remarketing use case wasn't working in the new structure

### DIFF
--- a/services/news/src/index.ts
+++ b/services/news/src/index.ts
@@ -44,7 +44,7 @@ app.get('/', async (req: Request, res: Response) => {
     EXTERNAL_PORT,
     HOME_HOST,
     SSP_TAG_URL: new URL(
-      `https://${SSP_HOST}:${EXTERNAL_PORT}/js/ssp/run-simple-ad-auction.js`,
+      `https://${AD_SERVER_HOST}:${EXTERNAL_PORT}/js/ssp/run-simple-ad-auction.js`,
     ).toString(),
   });
 });


### PR DESCRIPTION
**Prior to creating a pull request, please follow all the steps in the [contributing guide](CONTRIBUTING.md).**

# Description

The Remarketing use case wasn't working because the demo was creating the IG owner was DSP_HOST but it wasn't including DSP_HOST in the auction. 

The second possible solution is to add DSP_HOST as a possible buyer for SSP_HOST in the BUYER_HOSTS_TO_INTEGRATE_BY_SELLER_HOST variable (https://github.com/sidneyzanetti/privacy-sandbox-demos/blob/dev/services/ad-tech/src/lib/constants.ts#L185) but I'm not sure if it could have any other side effect in other use cases.


## Affected services

- [ ] Home
- [X] News
- [ ] Shop
- [ ] Travel
- [ ] DSP
- [ ] SSP
- [ ] ALL

Other:
