### PR TITLE
hotfix for documentation index and deploy script

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,23 @@
 # Changelog
 
+## v2.0.0 (2025/2/21)
+
+- added framework skeleton for synthetic monitoring (see monitoring/puppeteer-nodejs/ folder)
+- added support for Google Analytics in **home** service including consent banner
+- added configuration for .github/github-repo-stats.yml
+- Updated infrastructure to support additional dsp-x, dsp-y, ssp-y, ssp-y services
+- Added deployment instructions and scripts to support Podman on top of Docker. docs/deploy-to-linux-podman.md
+- Refactored the adtech services code into 1 services/adtech/ codebase. Removing code duplication and improving maintainability. Now dsp, ssp and
+  other adtech services can be instantiated (containerized) from the same code base.
+- Added new use case demos and refactored/updated existing ones.
+- Added new capabilities to the framework to enable new demos :
+  - support for buyerAndSellerReportingId in PAAPI auctions
+  - support for deals in PAAPI auctions
+  - support for multi-sellers, multi-buyers
+  - support for video ads in iframe using SSP macros
+  - publisher page (news site) to support multiple scenarios
+  - fenced frames ads reporting
+
 ## v1.3.0 (2024/2/6)
 
 ### Enhancements

--- a/scripts/firebase_deploy.sh
+++ b/scripts/firebase_deploy.sh
@@ -18,6 +18,11 @@
 source .env.deploy
 source ${ENV_FILE}
 
+# setup Google Cloud SDK project
+gcloud config set project $GCP_PROJECT_NAME
+gcloud config get-value project
+firebase use $GCP_PROJECT_NAME
+
 # Deploy to Firebase Hosting all sites
 for service in $SERVICES; do
   echo "deploying ${service}"

--- a/services/home/docs/intro.md
+++ b/services/home/docs/intro.md
@@ -11,13 +11,14 @@ Looking to run these demos yourself? Check our [guide](https://github.com/privac
 
 :::
 
-| **Use Case**                                                                                               | **Privacy Sandbox APIs**          |
-| ---------------------------------------------------------------------------------------------------------- | --------------------------------- |
-| [Basic retargeting / remarketing ad campaign](demos/retargeting-remarketing.md)                            | Protected Audience, Fenced Frames |
-| [Sequential setup of Protected Audience with contextual auction](demos/sequential-auction-setup.md)        | Protected Audience, Fenced Frames |
-| [Incorporating publisher ad quality requirements in Protected Audience](demos/publisher-ad-quality-req.md) | Protected Audience, Fenced Frames |
-| [In-stream video ads with Protected Audience](demos/instream-video-ad.md)                                  | Protected Audience                |
-| [Single-touch conversion attribution](demos/single-touch-conversion-attribution.md)                        | Attribution Reporting             |
+| **Use Case**                                                                                               | **Privacy Sandbox APIs**                                 |
+| ---------------------------------------------------------------------------------------------------------- | -------------------------------------------------------- |
+| [Basic retargeting / remarketing ad campaign](demos/retargeting-remarketing.md)                            | Protected Audience, Fenced Frames                        |
+| [Sequential setup of Protected Audience with contextual auction](demos/sequential-auction-setup.md)        | Protected Audience, Fenced Frames                        |
+| [Incorporating publisher ad quality requirements in Protected Audience](demos/publisher-ad-quality-req.md) | Protected Audience, Fenced Frames                        |
+| [In-stream video ads with Protected Audience](demos/instream-video-ad.md)                                  | Protected Audience                                       |
+| [Event-level reports for single touch attribution](demos/single-touch-event-level-report.md)               | Attribution Reporting                                    |
+| [Single-touch conversion attribution](demos/single-touch-conversion-attribution.md)                        | Protected Audience, Fenced Frames, Attribution Reporting |
 
 :::info
 


### PR DESCRIPTION
# Description

- Documentation index was missing one use case "Event-level reports for single touch attribution"
- Firebase deploy script was missing the project setting command

## Related Issue

NA

## Affected services

- [x] Home
- [ ] News
- [ ] Shop
- [ ] Travel
- [ ] DSP
- [ ] SSP
- [ ] ALL
- [x] Scripts

Other:
