### PR TITLE
Fix definitively invalid services/home docs issue

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -21,7 +21,7 @@ ci:
   autoupdate_branch: "dev"
   autoupdate_commit_msg: "[pre-commit.ci] pre-commit autoupdate"
   autoupdate_schedule: quarterly
-  skip: []
+  skip: [npm-build-services-home]
   submodules: false
 
 fail_fast: true

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -51,8 +51,9 @@ repos:
     hooks:
       - id: npm-build-services-home
         name: Build services/home docs
-        entry: sh -c 'cd services/home && npm run build'
+        entry: sh -c 'cd services/home && npm install && npm run build'
         language: system
         files: "^services/home.*"
         pass_filenames: false
         always_run: false
+        verbose: true

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -45,3 +45,14 @@ repos:
     hooks:
       - id: markdownlint-cli2
         name: lint markdown
+
+  # when home service docs are modified, try to build docs before commit
+  - repo: local
+    hooks:
+      - id: npm-build-services-home
+        name: Build services/home docs
+        entry: sh -c 'cd services/home && npm run build'
+        language: system
+        files: "^services/home.*"
+        pass_filenames: false
+        always_run: false

--- a/services/home/docs/demos/bidding-and-auction.md
+++ b/services/home/docs/demos/bidding-and-auction.md
@@ -376,8 +376,8 @@ app.locals = {
     </script>
 ```
 
-3. The [dsp-tag.js]
-   (<https://github.com/privacysandbox/privacy-sandbox-demos/blob/0558610e4712de7a5861bf2f2fa61126f1ffcdda/services/ad-tech/src/public/js/dsp/dsp-tag.js#L97>)
+3. The
+   [dsp-tag.js](https://github.com/privacysandbox/privacy-sandbox-demos/blob/0558610e4712de7a5861bf2f2fa61126f1ffcdda/services/ad-tech/src/public/js/dsp/dsp-tag.js#L97)
    will be executed for all DSPs. Within the tag, this DSP will inject an iframe to initiate the `joinAdInterestGroup` call.
 
 ```javascript


### PR DESCRIPTION
# Description

Introduced an additiona pre-commit hook that will try to build `services/home` when one of the markdown doc is modified (or docusaurus config is modified). Will prevent invalid markdown (MDX) to be merged causing CI/CD to fail in dev/stage environment.

Due to pre-commit.ci limitation, on github pre-commit won't run `npm-build-services-home`. Ensure that pre-commit is installed on your machine before commiting files.

additionally fix bidding&action syntax.

## Affected services

- [x] Home
- [ ] News
- [ ] Shop
- [ ] Travel
- [ ] DSP
- [ ] SSP
- [ ] ALL

Other:
- pre-commit config
