### PR TITLE
Bugfix/firebaserc fix service-provider

### DIFF
--- a/.firebaserc.template
+++ b/.firebaserc.template
@@ -50,7 +50,7 @@
         "ad-server": [
           "privacy-sandbox-demos-ad-server"
         ],
-        "services": [
+        "service-provider": [
           "privacy-sandbox-demos-services"
         ],
         "moto-news": [


### PR DESCRIPTION
## Description

Fix firebaserc.template to match "service-provider" service name

## Affected services

- [ ] Home
- [ ] News
- [ ] Shop
- [ ] Travel
- [ ] Ad-tech
- [ ] Service Provider
- [ ] ALL
- [x] Firebase

## Changelog

when deploying to firebase the target hosting site name must match the service name set in .env file. thus changing to "service-provider"