### PR TITLE
Update B&A Demo to work with B&A Servers running on GCP

### DIFF
--- a/.env
+++ b/.env
@@ -84,15 +84,17 @@ SSP_B_DETAIL="Ad-Platform: SSP-B for publisher"
 
 SSP_X_HOST=privacy-sandbox-demos-ssp-x.dev
 SSP_X_URI=http://privacy-sandbox-demos-ssp-x.dev:8080
-SSP_X_HOST_INTERNAL=ssp-x
 SSP_X_DETAIL="Ad-Platform: SSP-X for publisher"
 SSP_X_GRPC='172.16.0.104:50053'
+# SSP_X_GRPC="ssp-x-dev.sfe.privacy-sandbox-demos-ssp-x.dev:443"
+SSP_X_GRPC_SECURE="false"
 
 SSP_Y_HOST=privacy-sandbox-demos-ssp-y.dev
 SSP_Y_URI=http://privacy-sandbox-demos-ssp-y.dev:8080
-SSP_Y_HOST_INTERNAL=ssp-y
 SSP_Y_DETAIL="Ad-Platform: SSP-Y for publisher"
 SSP_Y_GRPC='172.16.0.204:50053'
+# SSP_Y_GRPC="ssp-y-dev.sfe.privacy-sandbox-demos-ssp-y.dev:443"
+SSP_Y_GRPC_SECURE="false"
 
 ## Collector for Aggregation Service
 COLLECTOR_HOST=privacy-sandbox-demos-collector.dev

--- a/cicd/.env.dev
+++ b/cicd/.env.dev
@@ -88,11 +88,15 @@ SSP_X_HOST=privacy-sandcastle-dev-ssp-x.web.app
 SSP_X_URI=https://privacy-sandcastle-dev-ssp-x.web.app
 SSP_X_TOKEN=""
 SSP_X_DETAIL="Ad-Platform: SSP-X for publisher"
+SSP_X_GRPC="ssp-x-dev.sfe.privacy-sandbox-demos-ssp-x.dev:443"
+SSP_X_GRPC_SECURE="true"
 
 SSP_Y_HOST=privacy-sandcastle-dev-ssp-y.web.app
 SSP_Y_URI=https://privacy-sandcastle-dev-ssp-y.web.app
 SSP_Y_TOKEN=""
 SSP_Y_DETAIL="Ad-Platform: SSP-Y for publisher"
+SSP_Y_GRPC="ssp-y-dev.sfe.privacy-sandbox-demos-ssp-y.dev:443"
+SSP_Y_GRPC_SECURE="true"
 
 ## Collector for Aggregation Service
 COLLECTOR_HOST=privacy-sandcastle-dev-collector.web.app

--- a/services/ad-tech/src/routes/ssp/usecase/bidding-and-auction/server/ssp-x-sfe-client.ts
+++ b/services/ad-tech/src/routes/ssp/usecase/bidding-and-auction/server/ssp-x-sfe-client.ts
@@ -4,6 +4,7 @@ import protoLoader from '@grpc/proto-loader';
 import grpc, {ChannelCredentials} from '@grpc/grpc-js';
 
 const GRPC_SERVER_ADDRESS = process.env.SSP_X_GRPC;
+const GRPC_SECURE_CONNECTION = process.env.SSP_X_GRPC_SECURE === 'true';
 let client: SellerFrontEnd | null = null;
 
 if (GRPC_SERVER_ADDRESS) {
@@ -35,12 +36,21 @@ if (GRPC_SERVER_ADDRESS) {
         },
       } = packageObject;
 
-      client = new SellerFrontEnd(
-        GRPC_SERVER_ADDRESS,
-        grpc.credentials.createInsecure(),
-      );
+      let credentials;
+      if (GRPC_SECURE_CONNECTION) {
+        console.log(
+          `SFE client for SSP-X: Using secure TLS connection to ${GRPC_SERVER_ADDRESS}`,
+        );
+        credentials = grpc.credentials.createSsl();
+      } else {
+        console.log(
+          `SFE client for SSP-X: Using insecure connection to ${GRPC_SERVER_ADDRESS}`,
+        );
+        credentials = grpc.credentials.createInsecure();
+      }
 
-      console.log('SFE client for SSP-X loaded successfully');
+      client = new SellerFrontEnd(GRPC_SERVER_ADDRESS, credentials);
+      console.log('SFE client for SSP-X gRPC client created.');
     } else {
       console.error(
         'Failed to load SellerFrontEnd service definition from proto.',

--- a/services/ad-tech/src/routes/ssp/usecase/bidding-and-auction/server/ssp-y-sfe-client.ts
+++ b/services/ad-tech/src/routes/ssp/usecase/bidding-and-auction/server/ssp-y-sfe-client.ts
@@ -4,6 +4,7 @@ import protoLoader from '@grpc/proto-loader';
 import grpc, {ChannelCredentials} from '@grpc/grpc-js';
 
 const GRPC_SERVER_ADDRESS = process.env.SSP_Y_GRPC;
+const GRPC_SECURE_CONNECTION = process.env.SSP_Y_GRPC_SECURE === 'true';
 let client: SellerFrontEnd | null = null;
 
 if (GRPC_SERVER_ADDRESS) {
@@ -35,12 +36,21 @@ if (GRPC_SERVER_ADDRESS) {
         },
       } = packageObject;
 
-      client = new SellerFrontEnd(
-        GRPC_SERVER_ADDRESS,
-        grpc.credentials.createInsecure(),
-      );
+      let credentials;
+      if (GRPC_SECURE_CONNECTION) {
+        console.log(
+          `SFE client for SSP-Y: Using secure TLS connection to ${GRPC_SERVER_ADDRESS}`,
+        );
+        credentials = grpc.credentials.createSsl();
+      } else {
+        console.log(
+          `SFE client for SSP-Y: Using insecure connection to ${GRPC_SERVER_ADDRESS}`,
+        );
+        credentials = grpc.credentials.createInsecure();
+      }
 
-      console.log('SFE client for SSP-Y loaded successfully');
+      client = new SellerFrontEnd(GRPC_SERVER_ADDRESS, credentials);
+      console.log('SFE client for SSP-Y gRPC client created.');
     } else {
       console.error(
         'Failed to load SellerFrontEnd service definition from proto.',


### PR DESCRIPTION
## Description

- ad-services.ts : add more logging and return 503 when B&A service is not available instead of just waiting for timeout
- ssp-x-sfe-client.ts and ssp-y-sfe-client.ts : update client creation to support both Insecure and Secure connections through a new flag "SSP_X_GRPC_SECURE" defined in the .env file. To communicate with the SFE on GCP through LB, you need to use a secure connection while for SFE running on local machine you would communicate directly with SFE (insecure connection)

## Affected services

- [ ] Home
- [ ] News
- [ ] Shop
- [ ] Travel
- [x] Ad-tech
- [ ] Service Provider
- [ ] ALL

## Changelog

update .env with new environment variable for "SSP_X_GRPC_SECURE" and "SSP_Y_GRPC_SECURE"   
update .env.dev with GRPC endpoint for testing with B&A Servers running on Google Cloud Platform.